### PR TITLE
Translate `mo_gas_optics_kernels`

### DIFF
--- a/src/rrtmgp/kernels/mo_gas_optics_kernels.jl
+++ b/src/rrtmgp/kernels/mo_gas_optics_kernels.jl
@@ -20,30 +20,7 @@ Description: Numeric calculations for gas optics. Absorption and Rayleigh optica
 """
 module mo_gas_optics_kernels
 
-"""
-    fmerge(t_source, f_source, mask)
-
-Based on: http://gcc.gnu.org/onlinedocs/gfortran/MERGE.html
-TODO: FIX IMPLEMENTATION
-"""
-fmerge(t_source, f_source, mask) = mask ? t_source : f_source
-
-"""
-    fminloc(a, dim, mask=nothing)
-
-Based on: https://gcc.gnu.org/onlinedocs/gfortran/MINLOC.html
-TODO: FIX IMPLEMENTATION
-"""
-fminloc(a; dim, mask=nothing) = mask==nothing ? argmin(a, dims=dim) : argmin(a[mask], dims=dim)
-
-"""
-    fmaxloc(a, dim=nothing, mask=nothing)
-
-Based on: https://gcc.gnu.org/onlinedocs/gfortran/MAXLOC.html
-TODO: FIX IMPLEMENTATION
-"""
-fmaxloc(a; dim, mask=nothing) = mask==nothing ? argmax(a, dims=dim) : argmax(a[mask], dims=dim)
-
+include("../../fortranfuncs.jl")
 
 """
     interpolation!(...)

--- a/src/rrtmgp/kernels/mo_gas_optics_kernels.jl
+++ b/src/rrtmgp/kernels/mo_gas_optics_kernels.jl
@@ -399,7 +399,7 @@ real(wp), dimension(ngpt) :: tau_minor
           # This check skips individual columns with no pressures in range
           #
           if layer_limits[icol,1] > 0
-            for ilay in layer_limits[icol,1], layer_limits[icol,2]
+            for ilay in layer_limits[icol,1]:layer_limits[icol,2]
               #
               # Scaling of minor gas absortion coefficient begins with column amount of minor gas
               #
@@ -541,7 +541,7 @@ real(wp) :: planck_function(nbnd,nlay+1,ncol)
       for ilay in 1:nlay
         # itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
         itropo = fmerge(1,2,tropo[icol,ilay])
-        for ibnd = 1, nbnd
+        for ibnd = 1:nbnd
           gptS = band_lims_gpt[1, ibnd]
           gptE = band_lims_gpt[2, ibnd]
           iflav = gpoint_flavor[itropo, gptS] #eta interpolation depends on band's flavor
@@ -747,7 +747,7 @@ integer :: igpt
     # each code block is for a different reference temperature
     DT = eltype(k)
     res = Vector{DT}(undef, gptE-gptS+1)
-    for igpt = 1, gptE-gptS+1
+    for igpt = 1:gptE-gptS+1
       res[igpt] =
         scaling[1] *
         ( fmajor[1,1,1] * k[gptS+igpt-1, jeta[1]  , jpress-1, jtemp  ] +
@@ -783,7 +783,7 @@ real(wp) :: t
         for igpt in 1:ngpt
            t = tau_abs[igpt,ilay,icol] + tau_rayleigh[igpt,ilay,icol]
            tau[icol,ilay,igpt] = t
-           g  (icol,ilay,igpt) = DT(0)
+           g[icol,ilay,igpt] = DT(0)
            if (t > DT(2) * realmin(DT))
              ssa[icol,ilay,igpt] = tau_rayleigh[igpt,ilay,icol] / t
            else
@@ -826,9 +826,11 @@ real(wp) :: t
           for imom = 1:nmom
             p[imom,icol,ilay,igpt] = DT(0)
           end
-          if (nmom >= 2) p[2,icol,ilay,igpt] = DT(0.1)
+          if (nmom >= 2)
+            p[2,icol,ilay,igpt] = DT(0.1)
+          end
         end
       end
     end
   end
-end module mo_gas_optics_kernels
+end

--- a/src/rrtmgp/kernels/mo_gas_optics_kernels.jl
+++ b/src/rrtmgp/kernels/mo_gas_optics_kernels.jl
@@ -1,773 +1,857 @@
-# This code is part of
-# RRTM for GCM Applications - Parallel (RRTMGP)
-#
-# Eli Mlawer and Robert Pincus
-# Andre Wehe and Jennifer Delamere
-# email:  rrtmgp@aer.com
-#
-# Copyright 2015,  Atmospheric and Environmental Research and
-# Regents of the University of Colorado.  All right reserved.
-#
-# Use and duplication is permitted under the terms of the
-#    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
-#
-# Description: Numeric calculations for gas optics. Absorption and Rayleigh optical depths,
-#   source functions.
+"""
 
+This code is part of
+
+RRTM for GCM Applications - Parallel (RRTMGP)
+
+Eli Mlawer and Robert Pincus
+Andre Wehe and Jennifer Delamere
+email:  rrtmgp@aer.com
+
+Copyright 2015,  Atmospheric and Environmental Research and
+Regents of the University of Colorado.  All right reserved.
+
+Use and duplication is permitted under the terms of the
+  BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+
+Description: Numeric calculations for gas optics. Absorption and Rayleigh optical depths,
+ source functions.
+
+"""
 module mo_gas_optics_kernels
-  use mo_rte_kind,      only : wp, wl
-  implicit none
-contains
-  # --------------------------------------------------------------------------------------
-  # Compute interpolation coefficients
-  # for calculations of major optical depths, minor optical depths, Rayleigh,
-  # and Planck fractions
-  subroutine interpolation( &
-                ncol,nlay,ngas,nflav,neta, npres, ntemp, &
-                flavor,                                  &
-                press_ref_log, temp_ref,press_ref_log_delta,    &
-                temp_ref_min,temp_ref_delta,press_ref_trop_log, &
-                vmr_ref,                                        &
-                play,tlay,col_gas,                              &
-                jtemp,fmajor,fminor,col_mix,tropo,jeta,jpress) bind(C, name="interpolation")
+
+"""
+    fmerge(t_source, f_source, mask)
+
+Based on: http://gcc.gnu.org/onlinedocs/gfortran/MERGE.html
+TODO: FIX IMPLEMENTATION
+"""
+fmerge(t_source, f_source, mask) = mask ? t_source : f_source
+
+"""
+    fminloc(a, dim, mask=nothing)
+
+Based on: https://gcc.gnu.org/onlinedocs/gfortran/MINLOC.html
+TODO: FIX IMPLEMENTATION
+"""
+fminloc(a; dim, mask=nothing) = mask==nothing ? argmin(a, dims=dim) : argmin(a[mask], dims=dim)
+
+"""
+    fmaxloc(a, dim=nothing, mask=nothing)
+
+Based on: https://gcc.gnu.org/onlinedocs/gfortran/MAXLOC.html
+TODO: FIX IMPLEMENTATION
+"""
+fmaxloc(a; dim, mask=nothing) = mask==nothing ? argmax(a, dims=dim) : argmax(a[mask], dims=dim)
+
+
+"""
+    interpolation!(...)
+
+Compute interpolation coefficients
+for calculations of major optical depths, minor optical depths, Rayleigh,
+and Planck fractions
+
+integer,                            intent(in) :: ncol,nlay
+integer,                            intent(in) :: ngas,nflav,neta,npres,ntemp
+integer,     dimension(2,nflav),    intent(in) :: flavor
+real(wp),    dimension(npres),      intent(in) :: press_ref_log
+real(wp),    dimension(ntemp),      intent(in) :: temp_ref
+real(wp),                           intent(in) :: press_ref_log_delta,
+                                                  temp_ref_min, temp_ref_delta,
+                                                  press_ref_trop_log
+real(wp),    dimension(2,0:ngas,ntemp), intent(in) :: vmr_ref
+
+# inputs from profile or parent function
+real(wp),    dimension(ncol,nlay),        intent(in) :: play, tlay
+real(wp),    dimension(ncol,nlay,0:ngas), intent(in) :: col_gas
+
+# outputs
+integer,     dimension(ncol,nlay), intent(out) :: jtemp, jpress
+logical(wl), dimension(ncol,nlay), intent(out) :: tropo
+integer,     dimension(2,    nflav,ncol,nlay), intent(out) :: jeta
+real(wp),    dimension(2,    nflav,ncol,nlay), intent(out) :: col_mix
+real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(out) :: fmajor
+real(wp),    dimension(2,2,  nflav,ncol,nlay), intent(out) :: fminor
+# -----------------
+# local
+real(wp), dimension(ncol,nlay) :: ftemp, fpress # interpolation fraction for temperature, pressure
+real(wp) :: locpress # needed to find location in pressure grid
+real(wp) :: ratio_eta_half # ratio of vmrs of major species that defines eta=0.5
+                           # for given flavor and reference temperature level
+real(wp) :: eta, feta      # binary_species_parameter, interpolation variable for eta
+real(wp) :: loceta         # needed to find location in eta grid
+real(wp) :: ftemp_term
+# -----------------
+# local indexes
+integer :: icol, ilay, iflav, igases(2), itropo, itemp
+"""
+  function interpolation!(
+                ncol,nlay,ngas,nflav,neta, npres, ntemp,
+                flavor,
+                press_ref_log, temp_ref,press_ref_log_delta,
+                temp_ref_min,temp_ref_delta,press_ref_trop_log,
+                vmr_ref,
+                play,tlay,col_gas,
+                jtemp,fmajor,fminor,col_mix,tropo,jeta,jpress)
     # input dimensions
-    integer,                            intent(in) :: ncol,nlay
-    integer,                            intent(in) :: ngas,nflav,neta,npres,ntemp
-    integer,     dimension(2,nflav),    intent(in) :: flavor
-    real(wp),    dimension(npres),      intent(in) :: press_ref_log
-    real(wp),    dimension(ntemp),      intent(in) :: temp_ref
-    real(wp),                           intent(in) :: press_ref_log_delta, &
-                                                      temp_ref_min, temp_ref_delta, &
-                                                      press_ref_trop_log
-    real(wp),    dimension(2,0:ngas,ntemp), intent(in) :: vmr_ref
+    DT = eltype(temp_ref)
 
-    # inputs from profile or parent function
-    real(wp),    dimension(ncol,nlay),        intent(in) :: play, tlay
-    real(wp),    dimension(ncol,nlay,0:ngas), intent(in) :: col_gas
-
-    # outputs
-    integer,     dimension(ncol,nlay), intent(out) :: jtemp, jpress
-    logical(wl), dimension(ncol,nlay), intent(out) :: tropo
-    integer,     dimension(2,    nflav,ncol,nlay), intent(out) :: jeta
-    real(wp),    dimension(2,    nflav,ncol,nlay), intent(out) :: col_mix
-    real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(out) :: fmajor
-    real(wp),    dimension(2,2,  nflav,ncol,nlay), intent(out) :: fminor
-    # -----------------
-    # local
-    real(wp), dimension(ncol,nlay) :: ftemp, fpress # interpolation fraction for temperature, pressure
-    real(wp) :: locpress # needed to find location in pressure grid
-    real(wp) :: ratio_eta_half # ratio of vmrs of major species that defines eta=0.5
-                               # for given flavor and reference temperature level
-    real(wp) :: eta, feta      # binary_species_parameter, interpolation variable for eta
-    real(wp) :: loceta         # needed to find location in eta grid
-    real(wp) :: ftemp_term
-    # -----------------
-    # local indexes
-    integer :: icol, ilay, iflav, igases(2), itropo, itemp
-
-    do ilay = 1, nlay
-      do icol = 1, ncol
+    for ilay in 1:nlay
+      for icol in 1:ncol
         # index and factor for temperature interpolation
-        jtemp(icol,ilay) = int((tlay(icol,ilay) - (temp_ref_min - temp_ref_delta)) / temp_ref_delta)
-        jtemp(icol,ilay) = min(ntemp - 1, max(1, jtemp(icol,ilay))) # limit the index range
-        ftemp(icol,ilay) = (tlay(icol,ilay) - temp_ref(jtemp(icol,ilay))) / temp_ref_delta
+        jtemp[icol,ilay] = int((tlay[icol,ilay] - (temp_ref_min - temp_ref_delta)) / temp_ref_delta)
+        jtemp[icol,ilay] = min(ntemp - 1, max(1, jtemp[icol,ilay])) # limit the index range
+        ftemp[icol,ilay] = (tlay[icol,ilay] - temp_ref[jtemp[icol,ilay]]) / temp_ref_delta
 
         # index and factor for pressure interpolation
-        locpress = 1._wp + (log(play(icol,ilay)) - press_ref_log(1)) / press_ref_log_delta
-        jpress(icol,ilay) = min(npres-1, max(1, int(locpress)))
-        fpress(icol,ilay) = locpress - float(jpress(icol,ilay))
+        locpress = DT(1) + (log(play[icol,ilay]) - press_ref_log[1]) / press_ref_log_delta
+        jpress[icol,ilay] = min(npres-1, max(1, int(locpress)))
+        fpress[icol,ilay] = locpress - DT(jpress[icol,ilay])
 
         # determine if in lower or upper part of atmosphere
-        tropo(icol,ilay) = log(play(icol,ilay)) > press_ref_trop_log
-      end do
-    end do
+        tropo[icol,ilay] = log(play[icol,ilay]) > press_ref_trop_log
+      end
+    end
 
-    do ilay = 1, nlay
-      do icol = 1, ncol
+    for ilay in 1:nlay
+      for icol in 1:ncol
         # itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
-        itropo = merge(1,2,tropo(icol,ilay))
+        itropo = fmerge(1,2,tropo[icol,ilay])
         # loop over implemented combinations of major species
-        do iflav = 1, nflav
-          igases(:) = flavor(:,iflav)
-          do itemp = 1, 2
+        for iflav in 1:nflav
+          igases[:] = flavor[:,iflav]
+          for itemp in 1:2
             # compute interpolation fractions needed for lower, then upper reference temperature level
             # compute binary species parameter (eta) for flavor and temperature and
             #  associated interpolation index and factors
-            ratio_eta_half = vmr_ref(itropo,igases(1),(jtemp(icol,ilay)+itemp-1)) / &
-                             vmr_ref(itropo,igases(2),(jtemp(icol,ilay)+itemp-1))
-            col_mix(itemp,iflav,icol,ilay) = col_gas(icol,ilay,igases(1)) + ratio_eta_half * col_gas(icol,ilay,igases(2))
-            eta = merge(col_gas(icol,ilay,igases(1)) / col_mix(itemp,iflav,icol,ilay), 0.5_wp, &
-                        col_mix(itemp,iflav,icol,ilay) > 2._wp * tiny(col_mix))
-            loceta = eta * float(neta-1)
-            jeta(itemp,iflav,icol,ilay) = min(int(loceta)+1, neta-1)
-            feta = mod(loceta, 1.0_wp)
+            ratio_eta_half = vmr_ref[itropo,igases[1],(jtemp[icol,ilay]+itemp-1)] /
+                             vmr_ref[itropo,igases[2],(jtemp[icol,ilay]+itemp-1)]
+            col_mix[itemp,iflav,icol,ilay] = col_gas[icol,ilay,igases[1]] + ratio_eta_half * col_gas[icol,ilay,igases[2]]
+            eta = fmerge(col_gas[icol,ilay,igases[1]] / col_mix[itemp,iflav,icol,ilay], DT(0.5),
+                        col_mix[itemp,iflav,icol,ilay] > DT(2) * floatmin(DT))
+            loceta = eta * DT(neta-1)
+            jeta[itemp,iflav,icol,ilay] = min(int(loceta)+1, neta-1)
+            feta = mod(loceta, 1)
             # compute interpolation fractions needed for minor species
-            # ftemp_term = (1._wp-ftemp(icol,ilay)) for itemp = 1, ftemp(icol,ilay) for itemp=2
-            ftemp_term = (real(2-itemp, wp) + real(2*itemp-3, wp) * ftemp(icol,ilay))
-            fminor(1,itemp,iflav,icol,ilay) = (1._wp-feta) * ftemp_term
-            fminor(2,itemp,iflav,icol,ilay) =        feta  * ftemp_term
+            # ftemp_term = (DT(1)-ftemp(icol,ilay)) for itemp = 1, ftemp(icol,ilay) for itemp=2
+            ftemp_term = (DT(2-itemp) + DT(2*itemp-3) * ftemp[icol,ilay])
+            fminor[1,itemp,iflav,icol,ilay] = (1-feta) * ftemp_term
+            fminor[2,itemp,iflav,icol,ilay] =        feta  * ftemp_term
             # compute interpolation fractions needed for major species
-            fmajor(1,1,itemp,iflav,icol,ilay) = (1._wp-fpress(icol,ilay)) * fminor(1,itemp,iflav,icol,ilay)
-            fmajor(2,1,itemp,iflav,icol,ilay) = (1._wp-fpress(icol,ilay)) * fminor(2,itemp,iflav,icol,ilay)
-            fmajor(1,2,itemp,iflav,icol,ilay) =        fpress(icol,ilay)  * fminor(1,itemp,iflav,icol,ilay)
-            fmajor(2,2,itemp,iflav,icol,ilay) =        fpress(icol,ilay)  * fminor(2,itemp,iflav,icol,ilay)
-          end do # reference temperatures
-        end do # iflav
-      end do # icol,ilay
-    end do
+            fmajor[1,1,itemp,iflav,icol,ilay] = (DT(1)-fpress[icol,ilay]) * fminor[1,itemp,iflav,icol,ilay]
+            fmajor[2,1,itemp,iflav,icol,ilay] = (DT(1)-fpress[icol,ilay]) * fminor[2,itemp,iflav,icol,ilay]
+            fmajor[1,2,itemp,iflav,icol,ilay] =        fpress[icol,ilay]  * fminor[1,itemp,iflav,icol,ilay]
+            fmajor[2,2,itemp,iflav,icol,ilay] =        fpress[icol,ilay]  * fminor[2,itemp,iflav,icol,ilay]
+          end # reference temperatures
+        end # iflav
+      end # icol,ilay
+    end
 
-  end subroutine interpolation
-  # --------------------------------------------------------------------------------------
-  #
-  # Compute minor and major species opitcal depth from pre-computed interpolation coefficients
-  #   (jeta,jtemp,jpress)
-  #
-  subroutine compute_tau_absorption(                &
-                ncol,nlay,nbnd,ngpt,                &  # dimensions
-                ngas,nflav,neta,npres,ntemp,        &
-                nminorlower, nminorklower,          & # number of minor contributors, total num absorption coeffs
-                nminorupper, nminorkupper,          &
-                idx_h2o,                            &
-                gpoint_flavor,                      &
-                band_lims_gpt,                      &
-                kmajor,                             &
-                kminor_lower,                       &
-                kminor_upper,                       &
-                minor_limits_gpt_lower,             &
-                minor_limits_gpt_upper,             &
-                minor_scales_with_density_lower,    &
-                minor_scales_with_density_upper,    &
-                scale_by_complement_lower,          &
-                scale_by_complement_upper,          &
-                idx_minor_lower,                    &
-                idx_minor_upper,                    &
-                idx_minor_scaling_lower,            &
-                idx_minor_scaling_upper,            &
-                kminor_start_lower,                 &
-                kminor_start_upper,                 &
-                tropo,                              &
-                col_mix,fmajor,fminor,              &
-                play,tlay,col_gas,                  &
-                jeta,jtemp,jpress,                  &
-                tau) bind(C, name="compute_tau_absorption")
-    # ---------------------
-    # input dimensions
-    integer,                                intent(in) :: ncol,nlay,nbnd,ngpt
-    integer,                                intent(in) :: ngas,nflav,neta,npres,ntemp
-    integer,                                intent(in) :: nminorlower, nminorklower,nminorupper, nminorkupper
-    integer,                                intent(in) :: idx_h2o
-    # ---------------------
-    # inputs from object
-    integer,     dimension(2,ngpt),                  intent(in) :: gpoint_flavor
-    integer,     dimension(2,nbnd),                  intent(in) :: band_lims_gpt
-    real(wp),    dimension(ngpt,neta,npres+1,ntemp), intent(in) :: kmajor
-    real(wp),    dimension(nminorklower,neta,ntemp), intent(in) :: kminor_lower
-    real(wp),    dimension(nminorkupper,neta,ntemp), intent(in) :: kminor_upper
-    integer,     dimension(2,nminorlower),           intent(in) :: minor_limits_gpt_lower
-    integer,     dimension(2,nminorupper),           intent(in) :: minor_limits_gpt_upper
-    logical(wl), dimension(  nminorlower),           intent(in) :: minor_scales_with_density_lower
-    logical(wl), dimension(  nminorupper),           intent(in) :: minor_scales_with_density_upper
-    logical(wl), dimension(  nminorlower),           intent(in) :: scale_by_complement_lower
-    logical(wl), dimension(  nminorupper),           intent(in) :: scale_by_complement_upper
-    integer,     dimension(  nminorlower),           intent(in) :: idx_minor_lower
-    integer,     dimension(  nminorupper),           intent(in) :: idx_minor_upper
-    integer,     dimension(  nminorlower),           intent(in) :: idx_minor_scaling_lower
-    integer,     dimension(  nminorupper),           intent(in) :: idx_minor_scaling_upper
-    integer,     dimension(  nminorlower),           intent(in) :: kminor_start_lower
-    integer,     dimension(  nminorupper),           intent(in) :: kminor_start_upper
-    logical(wl), dimension(ncol,nlay),               intent(in) :: tropo
-    # ---------------------
-    # inputs from profile or parent function
-    real(wp), dimension(2,    nflav,ncol,nlay       ), intent(in) :: col_mix
-    real(wp), dimension(2,2,2,nflav,ncol,nlay       ), intent(in) :: fmajor
-    real(wp), dimension(2,2,  nflav,ncol,nlay       ), intent(in) :: fminor
-    real(wp), dimension(            ncol,nlay       ), intent(in) :: play, tlay      # pressure and temperature
-    real(wp), dimension(            ncol,nlay,0:ngas), intent(in) :: col_gas
-    integer,  dimension(2,    nflav,ncol,nlay       ), intent(in) :: jeta
-    integer,  dimension(            ncol,nlay       ), intent(in) :: jtemp
-    integer,  dimension(            ncol,nlay       ), intent(in) :: jpress
-    # ---------------------
-    # output - optical depth
-    real(wp), dimension(ngpt,nlay,ncol), intent(inout) :: tau
-    # ---------------------
-    # Local variables
-    #
-    logical                    :: top_at_1
-    integer, dimension(ncol,2) :: itropo_lower, itropo_upper
-    # ----------------------------------------------------------------
+  end
+
+"""
+    compute_tau_absorption!(...)
+
+Compute minor and major species opitcal depth from pre-computed interpolation coefficients
+ (jeta,jtemp,jpress)
+
+# ---------------------
+# input dimensions
+integer,                                intent(in) :: ncol,nlay,nbnd,ngpt
+integer,                                intent(in) :: ngas,nflav,neta,npres,ntemp
+integer,                                intent(in) :: nminorlower, nminorklower,nminorupper, nminorkupper
+integer,                                intent(in) :: idx_h2o
+# ---------------------
+# inputs from object
+integer,     dimension(2,ngpt),                  intent(in) :: gpoint_flavor
+integer,     dimension(2,nbnd),                  intent(in) :: band_lims_gpt
+real(wp),    dimension(ngpt,neta,npres+1,ntemp), intent(in) :: kmajor
+real(wp),    dimension(nminorklower,neta,ntemp), intent(in) :: kminor_lower
+real(wp),    dimension(nminorkupper,neta,ntemp), intent(in) :: kminor_upper
+integer,     dimension(2,nminorlower),           intent(in) :: minor_limits_gpt_lower
+integer,     dimension(2,nminorupper),           intent(in) :: minor_limits_gpt_upper
+logical(wl), dimension(  nminorlower),           intent(in) :: minor_scales_with_density_lower
+logical(wl), dimension(  nminorupper),           intent(in) :: minor_scales_with_density_upper
+logical(wl), dimension(  nminorlower),           intent(in) :: scale_by_complement_lower
+logical(wl), dimension(  nminorupper),           intent(in) :: scale_by_complement_upper
+integer,     dimension(  nminorlower),           intent(in) :: idx_minor_lower
+integer,     dimension(  nminorupper),           intent(in) :: idx_minor_upper
+integer,     dimension(  nminorlower),           intent(in) :: idx_minor_scaling_lower
+integer,     dimension(  nminorupper),           intent(in) :: idx_minor_scaling_upper
+integer,     dimension(  nminorlower),           intent(in) :: kminor_start_lower
+integer,     dimension(  nminorupper),           intent(in) :: kminor_start_upper
+logical(wl), dimension(ncol,nlay),               intent(in) :: tropo
+# ---------------------
+# inputs from profile or parent function
+real(wp), dimension(2,    nflav,ncol,nlay       ), intent(in) :: col_mix
+real(wp), dimension(2,2,2,nflav,ncol,nlay       ), intent(in) :: fmajor
+real(wp), dimension(2,2,  nflav,ncol,nlay       ), intent(in) :: fminor
+real(wp), dimension(            ncol,nlay       ), intent(in) :: play, tlay      # pressure and temperature
+real(wp), dimension(            ncol,nlay,0:ngas), intent(in) :: col_gas
+integer,  dimension(2,    nflav,ncol,nlay       ), intent(in) :: jeta
+integer,  dimension(            ncol,nlay       ), intent(in) :: jtemp
+integer,  dimension(            ncol,nlay       ), intent(in) :: jpress
+# ---------------------
+# output - optical depth
+real(wp), dimension(ngpt,nlay,ncol), intent(inout) :: tau
+# ---------------------
+# Local variables
+#
+logical                    :: top_at_1
+integer, dimension(ncol,2) :: itropo_lower, itropo_upper
+"""
+  function compute_tau_absorption!(
+                ncol,nlay,nbnd,ngpt,                  # dimensions
+                ngas,nflav,neta,npres,ntemp,
+                nminorlower, nminorklower,           # number of minor contributors, total num absorption coeffs
+                nminorupper, nminorkupper,
+                idx_h2o,
+                gpoint_flavor,
+                band_lims_gpt,
+                kmajor,
+                kminor_lower,
+                kminor_upper,
+                minor_limits_gpt_lower,
+                minor_limits_gpt_upper,
+                minor_scales_with_density_lower,
+                minor_scales_with_density_upper,
+                scale_by_complement_lower,
+                scale_by_complement_upper,
+                idx_minor_lower,
+                idx_minor_upper,
+                idx_minor_scaling_lower,
+                idx_minor_scaling_upper,
+                kminor_start_lower,
+                kminor_start_upper,
+                tropo,
+                col_mix,fmajor,fminor,
+                play,tlay,col_gas,
+                jeta,jtemp,jpress,
+                tau)
 
     # ---------------------
     # Layer limits of upper, lower atmospheres
     # ---------------------
-    top_at_1 = play(1,1) < play(1, nlay)
-    if(top_at_1) then
-      itropo_lower(:, 1) = minloc(play, dim=2, mask=tropo)
-      itropo_lower(:, 2) = nlay
-      itropo_upper(:, 1) = 1
-      itropo_upper(:, 2) = maxloc(play, dim=2, mask=(.not. tropo))
+    top_at_1 = play[1,1] < play[1, nlay]
+    if top_at_1
+      itropo_lower[:, 1] = fminloc(play, dim=2, mask=tropo)
+      itropo_lower[:, 2] = nlay
+      itropo_upper[:, 1] = 1
+      itropo_upper[:, 2] = fmaxloc(play, dim=2, mask=(.!tropo)) # TODO:
     else
-      itropo_lower(:, 1) = 1
-      itropo_lower(:, 2) = minloc(play, dim=2, mask= tropo)
-      itropo_upper(:, 1) = maxloc(play, dim=2, mask=(.not. tropo))
-      itropo_upper(:, 2) = nlay
-    end if
+      itropo_lower[:, 1] = 1
+      itropo_lower[:, 2] = fminloc(play, dim=2, mask= tropo)
+      itropo_upper[:, 1] = fmaxloc(play, dim=2, mask=(.!tropo))
+      itropo_upper[:, 2] = nlay
+    end
     # ---------------------
     # Major Species
     # ---------------------
-    call gas_optical_depths_major(   &
-          ncol,nlay,nbnd,ngpt,       & # dimensions
-          nflav,neta,npres,ntemp,    &
-          gpoint_flavor,             &
-          band_lims_gpt,             &
-          kmajor,                    &
-          col_mix,fmajor,            &
-          jeta,tropo,jtemp,jpress,   &
+    gas_optical_depths_major!(
+          ncol,nlay,nbnd,ngpt,        # dimensions
+          nflav,neta,npres,ntemp,
+          gpoint_flavor,
+          band_lims_gpt,
+          kmajor,
+          col_mix,fmajor,
+          jeta,tropo,jtemp,jpress,
           tau)
     # ---------------------
     # Minor Species - lower
     # ---------------------
-    call gas_optical_depths_minor(     &
-           ncol,nlay,ngpt,             & # dimensions
-           ngas,nflav,ntemp,neta,      &
-           nminorlower,nminorklower,   &
-           idx_h2o,                    &
-           gpoint_flavor(1,:),         &
-           kminor_lower,               &
-           minor_limits_gpt_lower,     &
-           minor_scales_with_density_lower, &
-           scale_by_complement_lower,  &
-           idx_minor_lower,            &
-           idx_minor_scaling_lower,    &
-           kminor_start_lower,         &
-           play, tlay,                 &
-           col_gas,fminor,jeta,        &
-           itropo_lower,jtemp,         &
+    gas_optical_depths_minor!(
+           ncol,nlay,ngpt,              # dimensions
+           ngas,nflav,ntemp,neta,
+           nminorlower,nminorklower,
+           idx_h2o,
+           gpoint_flavor[1,:],
+           kminor_lower,
+           minor_limits_gpt_lower,
+           minor_scales_with_density_lower,
+           scale_by_complement_lower,
+           idx_minor_lower,
+           idx_minor_scaling_lower,
+           kminor_start_lower,
+           play, tlay,
+           col_gas,fminor,jeta,
+           itropo_lower,jtemp,
            tau)
     # ---------------------
     # Minor Species - upper
     # ---------------------
-    call gas_optical_depths_minor(     &
-           ncol,nlay,ngpt,             & # dimensions
-           ngas,nflav,ntemp,neta,      &
-           nminorupper,nminorkupper,   &
-           idx_h2o,                    &
-           gpoint_flavor(2,:),         &
-           kminor_upper,               &
-           minor_limits_gpt_upper,     &
-           minor_scales_with_density_upper, &
-           scale_by_complement_upper,  &
-           idx_minor_upper,            &
-           idx_minor_scaling_upper,    &
-           kminor_start_upper,         &
-           play, tlay,                 &
-           col_gas,fminor,jeta,        &
-           itropo_upper,jtemp,         &
+    gas_optical_depths_minor!(
+           ncol,nlay,ngpt,              # dimensions
+           ngas,nflav,ntemp,neta,
+           nminorupper,nminorkupper,
+           idx_h2o,
+           gpoint_flavor[2,:],
+           kminor_upper,
+           minor_limits_gpt_upper,
+           minor_scales_with_density_upper,
+           scale_by_complement_upper,
+           idx_minor_upper,
+           idx_minor_scaling_upper,
+           kminor_start_upper,
+           play, tlay,
+           col_gas,fminor,jeta,
+           itropo_upper,jtemp,
            tau)
-  end subroutine compute_tau_absorption
+  end
   # --------------------------------------------------------------------------------------
 
-  # --------------------------------------------------------------------------------------
-  #
-  # compute minor species optical depths
-  #
-  subroutine gas_optical_depths_major(ncol,nlay,nbnd,ngpt,&
-                                      nflav,neta,npres,ntemp,      & # dimensions
-                                      gpoint_flavor, band_lims_gpt,   & # inputs from object
-                                      kmajor,                         &
-                                      col_mix,fmajor,                 &
-                                      jeta,tropo,jtemp,jpress,        & # local input
-                                      tau) bind(C, name="gas_optical_depths_major")
-    # input dimensions
-    integer, intent(in) :: ncol, nlay, nbnd, ngpt, nflav,neta,npres,ntemp  # dimensions
+"""
+    gas_optical_depths_major!(...)
 
-    # inputs from object
-    integer,  dimension(2,ngpt),  intent(in) :: gpoint_flavor
-    integer,  dimension(2,nbnd),  intent(in) :: band_lims_gpt # start and end g-point for each band
-    real(wp), dimension(ngpt,neta,npres+1,ntemp), intent(in) :: kmajor
+compute minor species optical depths
 
-    # inputs from profile or parent function
-    real(wp),    dimension(2,    nflav,ncol,nlay), intent(in) :: col_mix
-    real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(in) :: fmajor
-    integer,     dimension(2,    nflav,ncol,nlay), intent(in) :: jeta
-    logical(wl), dimension(ncol,nlay), intent(in) :: tropo
-    integer,     dimension(ncol,nlay), intent(in) :: jtemp, jpress
 
-    # outputs
-    real(wp), dimension(ngpt,nlay,ncol), intent(inout) :: tau
-    # -----------------
-    # local variables
-    real(wp) :: tau_major(ngpt) # major species optical depth
-    # local index
-    integer :: icol, ilay, iflav, ibnd, igpt, itropo
-    integer :: gptS, gptE
+# input dimensions
+integer, intent(in) :: ncol, nlay, nbnd, ngpt, nflav,neta,npres,ntemp  # dimensions
 
-    # -----------------
+# inputs from object
+integer,  dimension(2,ngpt),  intent(in) :: gpoint_flavor
+integer,  dimension(2,nbnd),  intent(in) :: band_lims_gpt # start and end g-point for each band
+real(wp), dimension(ngpt,neta,npres+1,ntemp), intent(in) :: kmajor
 
-    do icol = 1, ncol
-      do ilay = 1, nlay
+# inputs from profile or parent function
+real(wp),    dimension(2,    nflav,ncol,nlay), intent(in) :: col_mix
+real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(in) :: fmajor
+integer,     dimension(2,    nflav,ncol,nlay), intent(in) :: jeta
+logical(wl), dimension(ncol,nlay), intent(in) :: tropo
+integer,     dimension(ncol,nlay), intent(in) :: jtemp, jpress
+
+# outputs
+real(wp), dimension(ngpt,nlay,ncol), intent(inout) :: tau
+# -----------------
+# local variables
+real(wp) :: tau_major(ngpt) # major species optical depth
+# local index
+integer :: icol, ilay, iflav, ibnd, igpt, itropo
+integer :: gptS, gptE
+"""
+  function gas_optical_depths_major!(ncol,nlay,nbnd,ngpt,
+                                      nflav,neta,npres,ntemp,       # dimensions
+                                      gpoint_flavor, band_lims_gpt,    # inputs from object
+                                      kmajor,
+                                      col_mix,fmajor,
+                                      jeta,tropo,jtemp,jpress,         # local input
+                                      tau)
+
+    for icol in 1:ncol
+      for ilay in 1:nlay
         # itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
-        itropo = merge(1,2,tropo(icol,ilay))
+        itropo = fmerge(1,2,tropo[icol,ilay])
         # optical depth calculation for major species
-        do ibnd = 1, nbnd
-          gptS = band_lims_gpt(1, ibnd)
-          gptE = band_lims_gpt(2, ibnd)
-          iflav = gpoint_flavor(itropo, gptS) #eta interpolation depends on band's flavor
-          tau_major(gptS:gptE) = &
+        for ibnd in 1:nbnd
+          gptS = band_lims_gpt[1, ibnd]
+          gptE = band_lims_gpt[2, ibnd]
+          iflav = gpoint_flavor[itropo, gptS] #eta interpolation depends on band's flavor
+          tau_major[gptS:gptE] =
             # interpolation in temperature, pressure, and eta
-            interpolate3D_byflav(col_mix(:,iflav,icol,ilay),                                     &
-                                 fmajor(:,:,:,iflav,icol,ilay), kmajor,                          &
-                                 band_lims_gpt(1, ibnd), band_lims_gpt(2, ibnd),                 &
-                                 jeta(:,iflav,icol,ilay), jtemp(icol,ilay),jpress(icol,ilay)+itropo)
-          tau(gptS:gptE,ilay,icol) = tau(gptS:gptE,ilay,icol) + tau_major(gptS:gptE)
-        end do # igpt
-      end do
-    end do # ilay
-  end subroutine gas_optical_depths_major
+            interpolate3D_byflav(col_mix[:,iflav,icol,ilay],
+                                 fmajor[:,:,:,iflav,icol,ilay], kmajor,
+                                 band_lims_gpt[1, ibnd], band_lims_gpt[2, ibnd],
+                                 jeta[:,iflav,icol,ilay], jtemp[icol,ilay],jpress[icol,ilay]+itropo)
+          tau[gptS:gptE,ilay,icol] = tau[gptS:gptE,ilay,icol] + tau_major[gptS:gptE]
+        end # igpt
+      end
+    end # ilay
+  end
 
-  # ----------------------------------------------------------
-  #
-  # compute minor species optical depths
-  #
-  subroutine gas_optical_depths_minor(ncol,nlay,ngpt,        &
-                                      ngas,nflav,ntemp,neta, &
-                                      nminor,nminork,        &
-                                      idx_h2o,               &
-                                      gpt_flv,               &
-                                      kminor,                &
-                                      minor_limits_gpt,      &
-                                      minor_scales_with_density,    &
-                                      scale_by_complement,   &
-                                      idx_minor, idx_minor_scaling, &
-                                      kminor_start,          &
-                                      play, tlay,            &
-                                      col_gas,fminor,jeta,   &
-                                      layer_limits,jtemp,    &
-                                      tau) bind(C, name="gas_optical_depths_minor")
-    integer,                                     intent(in   ) :: ncol,nlay,ngpt
-    integer,                                     intent(in   ) :: ngas,nflav
-    integer,                                     intent(in   ) :: ntemp,neta,nminor,nminork
-    integer,                                     intent(in   ) :: idx_h2o
-    integer,     dimension(ngpt),                intent(in   ) :: gpt_flv
-    real(wp),    dimension(nminork,neta,ntemp),  intent(in   ) :: kminor
-    integer,     dimension(2,nminor),            intent(in   ) :: minor_limits_gpt
-    logical(wl), dimension(  nminor),            intent(in   ) :: minor_scales_with_density
-    logical(wl), dimension(  nminor),            intent(in   ) :: scale_by_complement
-    integer,     dimension(  nminor),            intent(in   ) :: kminor_start
-    integer,     dimension(  nminor),            intent(in   ) :: idx_minor, idx_minor_scaling
-    real(wp),    dimension(ncol,nlay),           intent(in   ) :: play, tlay
-    real(wp),    dimension(ncol,nlay,0:ngas),    intent(in   ) :: col_gas
-    real(wp),    dimension(2,2,nflav,ncol,nlay), intent(in   ) :: fminor
-    integer,     dimension(2,  nflav,ncol,nlay), intent(in   ) :: jeta
-    integer,     dimension(ncol, 2),             intent(in   ) :: layer_limits
-    integer,     dimension(ncol,nlay),           intent(in   ) :: jtemp
-    real(wp),    dimension(ngpt,nlay,ncol),      intent(inout) :: tau
-    # -----------------
-    # local variables
-    real(wp), parameter :: PaTohPa = 0.01
-    real(wp) :: vmr_fact, dry_fact             # conversion from column abundance to dry vol. mixing ratio;
-    real(wp) :: scaling, kminor_loc            # minor species absorption coefficient, optical depth
-    integer  :: icol, ilay, iflav, igpt, imnr
-    integer  :: gptS, gptE
-    real(wp), dimension(ngpt) :: tau_minor
-    # -----------------
+
+"""
+    gas_optical_depths_minor!(...)
+
+compute minor species optical depths
+
+
+integer,                                     intent(in   ) :: ncol,nlay,ngpt
+integer,                                     intent(in   ) :: ngas,nflav
+integer,                                     intent(in   ) :: ntemp,neta,nminor,nminork
+integer,                                     intent(in   ) :: idx_h2o
+integer,     dimension(ngpt),                intent(in   ) :: gpt_flv
+real(wp),    dimension(nminork,neta,ntemp),  intent(in   ) :: kminor
+integer,     dimension(2,nminor),            intent(in   ) :: minor_limits_gpt
+logical(wl), dimension(  nminor),            intent(in   ) :: minor_scales_with_density
+logical(wl), dimension(  nminor),            intent(in   ) :: scale_by_complement
+integer,     dimension(  nminor),            intent(in   ) :: kminor_start
+integer,     dimension(  nminor),            intent(in   ) :: idx_minor, idx_minor_scaling
+real(wp),    dimension(ncol,nlay),           intent(in   ) :: play, tlay
+real(wp),    dimension(ncol,nlay,0:ngas),    intent(in   ) :: col_gas
+real(wp),    dimension(2,2,nflav,ncol,nlay), intent(in   ) :: fminor
+integer,     dimension(2,  nflav,ncol,nlay), intent(in   ) :: jeta
+integer,     dimension(ncol, 2),             intent(in   ) :: layer_limits
+integer,     dimension(ncol,nlay),           intent(in   ) :: jtemp
+real(wp),    dimension(ngpt,nlay,ncol),      intent(inout) :: tau
+# -----------------
+# local variables
+real(wp), parameter :: PaTohPa = 0.01
+real(wp) :: vmr_fact, dry_fact             # conversion from column abundance to dry vol. mixing ratio;
+real(wp) :: scaling, kminor_loc            # minor species absorption coefficient, optical depth
+integer  :: icol, ilay, iflav, igpt, imnr
+integer  :: gptS, gptE
+real(wp), dimension(ngpt) :: tau_minor
+
+"""
+  function gas_optical_depths_minor!(ncol,nlay,ngpt,
+                                      ngas,nflav,ntemp,neta,
+                                      nminor,nminork,
+                                      idx_h2o,
+                                      gpt_flv,
+                                      kminor,
+                                      minor_limits_gpt,
+                                      minor_scales_with_density,
+                                      scale_by_complement,
+                                      idx_minor, idx_minor_scaling,
+                                      kminor_start,
+                                      play, tlay,
+                                      col_gas,fminor,jeta,
+                                      layer_limits,jtemp,
+                                      tau)
     #
     # Guard against layer limits being 0 -- that means don't do anything i.e. there are no
     #   layers with pressures in the upper or lower atmosphere respectively
     # First check skips the routine entirely if all columns are out of bounds...
     #
-    if(any(layer_limits(:,1) > 0)) then
-      do imnr = 1, size(scale_by_complement,dim=1) # loop over minor absorbers in each band
-        do icol = 1, ncol
+    DT = eltype(tau)
+    if any(layer_limits[:,1] .> 0)
+      for imnr in 1:size(scale_by_complement,dim=1) # loop over minor absorbers in each band
+        for icol in 1:ncol
           #
           # This check skips individual columns with no pressures in range
           #
-          if(layer_limits(icol,1) > 0) then
-            do ilay = layer_limits(icol,1), layer_limits(icol,2)
+          if layer_limits[icol,1] > 0
+            for ilay in layer_limits[icol,1], layer_limits[icol,2]
               #
               # Scaling of minor gas absortion coefficient begins with column amount of minor gas
               #
-              scaling = col_gas(icol,ilay,idx_minor(imnr))
+              scaling = col_gas[icol,ilay,idx_minor[imnr]]
               #
               # Density scaling (e.g. for h2o continuum, collision-induced absorption)
               #
-              if (minor_scales_with_density(imnr)) then
+              if minor_scales_with_density[imnr]
                 #
                 # NOTE: P needed in hPa to properly handle density scaling.
                 #
-                scaling = scaling * (PaTohPa*play(icol,ilay)/tlay(icol,ilay))
-                if(idx_minor_scaling(imnr) > 0) then  # there is a second gas that affects this gas's absorption
-                  vmr_fact = 1._wp / col_gas(icol,ilay,0)
-                  dry_fact = 1._wp / (1._wp + col_gas(icol,ilay,idx_h2o) * vmr_fact)
+                scaling = scaling * (PaTohPa*play[icol,ilay]/tlay[icol,ilay])
+                if idx_minor_scaling[imnr] > 0  # there is a second gas that affects this gas's absorption
+                  vmr_fact = DT(1) / col_gas[icol,ilay,0]
+                  dry_fact = DT(1) / (DT(1) + col_gas[icol,ilay,idx_h2o] * vmr_fact)
                   # scale by density of special gas
-                  if (scale_by_complement(imnr)) then # scale by densities of all gases but the special one
-                    scaling = scaling * (1._wp - col_gas(icol,ilay,idx_minor_scaling(imnr)) * vmr_fact * dry_fact)
+                  if scale_by_complement[imnr] # scale by densities of all gases but the special one
+                    scaling = scaling * (DT(1) - col_gas[icol,ilay,idx_minor_scaling[imnr]] * vmr_fact * dry_fact)
                   else
-                    scaling = scaling *          col_gas(icol,ilay,idx_minor_scaling(imnr)) * vmr_fact * dry_fact
-                  endif
-                endif
-              endif
+                    scaling = scaling *          col_gas[icol,ilay,idx_minor_scaling[imnr]] * vmr_fact * dry_fact
+                  end
+                end
+              end
               #
               # Interpolation of absorption coefficient and calculation of optical depth
               #
               # Which gpoint range does this minor gas affect?
-              gptS = minor_limits_gpt(1,imnr)
-              gptE = minor_limits_gpt(2,imnr)
-              iflav = gpt_flv(gptS)
-              tau_minor(gptS:gptE) = scaling *                   &
-                                      interpolate2D_byflav(fminor(:,:,iflav,icol,ilay), &
-                                                           kminor, &
-                                                           kminor_start(imnr), kminor_start(imnr)+(gptE-gptS), &
-                                                           jeta(:,iflav,icol,ilay), jtemp(icol,ilay))
-              tau(gptS:gptE,ilay,icol) = tau(gptS:gptE,ilay,icol) + tau_minor(gptS:gptE)
-            enddo
-          end if
-        enddo
-      enddo
-    end if
-  end subroutine gas_optical_depths_minor
-  # ----------------------------------------------------------
-  #
-  # compute Rayleigh scattering optical depths
-  #
-  subroutine compute_tau_rayleigh(ncol,nlay,nbnd,ngpt,         &
-                                  ngas,nflav,neta,npres,ntemp, &
-                                  gpoint_flavor,band_lims_gpt, &
-                                  krayl,                       &
-                                  idx_h2o, col_dry,col_gas,    &
-                                  fminor,jeta,tropo,jtemp,     &
-                                  tau_rayleigh) bind(C, name="compute_tau_rayleigh")
-    integer,                                     intent(in ) :: ncol,nlay,nbnd,ngpt
-    integer,                                     intent(in ) :: ngas,nflav,neta,npres,ntemp
-    integer,     dimension(2,ngpt),              intent(in ) :: gpoint_flavor
-    integer,     dimension(2,nbnd),              intent(in ) :: band_lims_gpt # start and end g-point for each band
-    real(wp),    dimension(ngpt,neta,ntemp,2),   intent(in ) :: krayl
-    integer,                                     intent(in ) :: idx_h2o
-    real(wp),    dimension(ncol,nlay),           intent(in ) :: col_dry
-    real(wp),    dimension(ncol,nlay,0:ngas),    intent(in ) :: col_gas
-    real(wp),    dimension(2,2,nflav,ncol,nlay), intent(in ) :: fminor
-    integer,     dimension(2,  nflav,ncol,nlay), intent(in ) :: jeta
-    logical(wl), dimension(ncol,nlay),           intent(in ) :: tropo
-    integer,     dimension(ncol,nlay),           intent(in ) :: jtemp
-    # outputs
-    real(wp),    dimension(ngpt,nlay,ncol),      intent(out) :: tau_rayleigh
-    # -----------------
-    # local variables
-    real(wp) :: k(ngpt) # rayleigh scattering coefficient
-    integer  :: icol, ilay, iflav, ibnd, igpt, gptS, gptE
-    integer  :: itropo
-    # -----------------
-    do ilay = 1, nlay
-      do icol = 1, ncol
-        itropo = merge(1,2,tropo(icol,ilay)) # itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
-        do ibnd = 1, nbnd
-          gptS = band_lims_gpt(1, ibnd)
-          gptE = band_lims_gpt(2, ibnd)
-          iflav = gpoint_flavor(itropo, gptS) #eta interpolation depends on band's flavor
-          k(gptS:gptE) = interpolate2D_byflav(fminor(:,:,iflav,icol,ilay), &
-                                              krayl(:,:,:,itropo),      &
-                                              gptS, gptE, jeta(:,iflav,icol,ilay), jtemp(icol,ilay))
-          tau_rayleigh(gptS:gptE,ilay,icol) = k(gptS:gptE) * &
-                                              (col_gas(icol,ilay,idx_h2o)+col_dry(icol,ilay))
-        end do
-      end do
-    end do
-  end subroutine compute_tau_rayleigh
+              gptS = minor_limits_gpt[1,imnr]
+              gptE = minor_limits_gpt[2,imnr]
+              iflav = gpt_flv[gptS]
+              tau_minor[gptS:gptE] = scaling *
+                                      interpolate2D_byflav(fminor[:,:,iflav,icol,ilay],
+                                                           kminor,
+                                                           kminor_start[imnr], kminor_start[imnr]+(gptE-gptS),
+                                                           jeta[:,iflav,icol,ilay], jtemp[icol,ilay])
+              tau[gptS:gptE,ilay,icol] = tau[gptS:gptE,ilay,icol] + tau_minor[gptS:gptE]
+            end
+          end
+        end
+      end
+    end
+  end
 
-  # ----------------------------------------------------------
-  subroutine compute_Planck_source(                        &
-                    ncol, nlay, nbnd, ngpt,                &
-                    nflav, neta, npres, ntemp, nPlanckTemp,&
-                    tlay, tlev, tsfc, sfc_lay,             &
-                    fmajor, jeta, tropo, jtemp, jpress,    &
-                    gpoint_bands, band_lims_gpt,           &
-                    pfracin, temp_ref_min, totplnk_delta, totplnk, gpoint_flavor, &
-                    sfc_src, lay_src, lev_src_inc, lev_src_dec) bind(C, name="compute_Planck_source")
-    integer,                                    intent(in) :: ncol, nlay, nbnd, ngpt
-    integer,                                    intent(in) :: nflav, neta, npres, ntemp, nPlanckTemp
-    real(wp),    dimension(ncol,nlay  ),        intent(in) :: tlay
-    real(wp),    dimension(ncol,nlay+1),        intent(in) :: tlev
-    real(wp),    dimension(ncol       ),        intent(in) :: tsfc
-    integer,                                    intent(in) :: sfc_lay
-    # Interpolation variables
-    real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(in) :: fmajor
-    integer,     dimension(2,    nflav,ncol,nlay), intent(in) :: jeta
-    logical(wl), dimension(            ncol,nlay), intent(in) :: tropo
-    integer,     dimension(            ncol,nlay), intent(in) :: jtemp, jpress
-    # Table-specific
-    integer, dimension(ngpt),                     intent(in) :: gpoint_bands # start and end g-point for each band
-    integer, dimension(2, nbnd),                  intent(in) :: band_lims_gpt # start and end g-point for each band
-    real(wp),                                     intent(in) :: temp_ref_min, totplnk_delta
-    real(wp), dimension(ngpt,neta,npres+1,ntemp), intent(in) :: pfracin
-    real(wp), dimension(nPlanckTemp,nbnd),        intent(in) :: totplnk
-    integer,  dimension(2,ngpt),                  intent(in) :: gpoint_flavor
+"""
+    compute_tau_rayleigh!()
 
-    real(wp), dimension(ngpt,     ncol), intent(out) :: sfc_src
-    real(wp), dimension(ngpt,nlay,ncol), intent(out) :: lay_src
-    real(wp), dimension(ngpt,nlay,ncol), intent(out) :: lev_src_inc, lev_src_dec
-    # -----------------
-    # local
-    integer  :: ilay, icol, igpt, ibnd, itropo, iflav
-    integer  :: gptS, gptE
-    real(wp), dimension(2), parameter :: one = [1._wp, 1._wp]
-    real(wp) :: pfrac          (ngpt,nlay,  ncol)
-    real(wp) :: planck_function(nbnd,nlay+1,ncol)
-    # -----------------
+compute Rayleigh scattering optical depths
+
+integer,                                     intent(in ) :: ncol,nlay,nbnd,ngpt
+integer,                                     intent(in ) :: ngas,nflav,neta,npres,ntemp
+integer,     dimension(2,ngpt),              intent(in ) :: gpoint_flavor
+integer,     dimension(2,nbnd),              intent(in ) :: band_lims_gpt # start and end g-point for each band
+real(wp),    dimension(ngpt,neta,ntemp,2),   intent(in ) :: krayl
+integer,                                     intent(in ) :: idx_h2o
+real(wp),    dimension(ncol,nlay),           intent(in ) :: col_dry
+real(wp),    dimension(ncol,nlay,0:ngas),    intent(in ) :: col_gas
+real(wp),    dimension(2,2,nflav,ncol,nlay), intent(in ) :: fminor
+integer,     dimension(2,  nflav,ncol,nlay), intent(in ) :: jeta
+logical(wl), dimension(ncol,nlay),           intent(in ) :: tropo
+integer,     dimension(ncol,nlay),           intent(in ) :: jtemp
+# outputs
+real(wp),    dimension(ngpt,nlay,ncol),      intent(out) :: tau_rayleigh
+# -----------------
+# local variables
+real(wp) :: k(ngpt) # rayleigh scattering coefficient
+integer  :: icol, ilay, iflav, ibnd, igpt, gptS, gptE
+integer  :: itropo
+# -----------------
+"""
+  function compute_tau_rayleigh!(ncol,nlay,nbnd,ngpt,
+                                  ngas,nflav,neta,npres,ntemp,
+                                  gpoint_flavor,band_lims_gpt,
+                                  krayl,
+                                  idx_h2o, col_dry,col_gas,
+                                  fminor,jeta,tropo,jtemp,
+                                  tau_rayleigh)
+    for ilay in 1:nlay
+      for icol in 1:ncol
+        itropo = fmerge(1,2,tropo[icol,ilay]) # itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
+        for ibnd in 1:nbnd
+          gptS = band_lims_gpt[1, ibnd]
+          gptE = band_lims_gpt[2, ibnd]
+          iflav = gpoint_flavor[itropo, gptS] #eta interpolation depends on band's flavor
+          k[gptS:gptE] = interpolate2D_byflav(fminor[:,:,iflav,icol,ilay],
+                                              krayl[:,:,:,itropo],
+                                              gptS, gptE, jeta[:,iflav,icol,ilay], jtemp[icol,ilay])
+          tau_rayleigh[gptS:gptE,ilay,icol] = k[gptS:gptE] *
+                                              (col_gas[icol,ilay,idx_h2o]+col_dry[icol,ilay])
+        end
+      end
+    end
+  end
+
+"""
+    compute_Planck_source!(...)
+
+integer,                                    intent(in) :: ncol, nlay, nbnd, ngpt
+integer,                                    intent(in) :: nflav, neta, npres, ntemp, nPlanckTemp
+real(wp),    dimension(ncol,nlay  ),        intent(in) :: tlay
+real(wp),    dimension(ncol,nlay+1),        intent(in) :: tlev
+real(wp),    dimension(ncol       ),        intent(in) :: tsfc
+integer,                                    intent(in) :: sfc_lay
+# Interpolation variables
+real(wp),    dimension(2,2,2,nflav,ncol,nlay), intent(in) :: fmajor
+integer,     dimension(2,    nflav,ncol,nlay), intent(in) :: jeta
+logical(wl), dimension(            ncol,nlay), intent(in) :: tropo
+integer,     dimension(            ncol,nlay), intent(in) :: jtemp, jpress
+# Table-specific
+integer, dimension(ngpt),                     intent(in) :: gpoint_bands # start and end g-point for each band
+integer, dimension(2, nbnd),                  intent(in) :: band_lims_gpt # start and end g-point for each band
+real(wp),                                     intent(in) :: temp_ref_min, totplnk_delta
+real(wp), dimension(ngpt,neta,npres+1,ntemp), intent(in) :: pfracin
+real(wp), dimension(nPlanckTemp,nbnd),        intent(in) :: totplnk
+integer,  dimension(2,ngpt),                  intent(in) :: gpoint_flavor
+
+real(wp), dimension(ngpt,     ncol), intent(out) :: sfc_src
+real(wp), dimension(ngpt,nlay,ncol), intent(out) :: lay_src
+real(wp), dimension(ngpt,nlay,ncol), intent(out) :: lev_src_inc, lev_src_dec
+# -----------------
+# local
+integer  :: ilay, icol, igpt, ibnd, itropo, iflav
+integer  :: gptS, gptE
+real(wp), dimension(2), parameter :: one = [1._wp, 1._wp]
+real(wp) :: pfrac          (ngpt,nlay,  ncol)
+real(wp) :: planck_function(nbnd,nlay+1,ncol)
+# -----------------
+"""
+  function compute_Planck_source!(
+                    ncol, nlay, nbnd, ngpt,
+                    nflav, neta, npres, ntemp, nPlanckTemp,
+                    tlay, tlev, tsfc, sfc_lay,
+                    fmajor, jeta, tropo, jtemp, jpress,
+                    gpoint_bands, band_lims_gpt,
+                    pfracin, temp_ref_min, totplnk_delta, totplnk, gpoint_flavor,
+                    sfc_src, lay_src, lev_src_inc, lev_src_dec)
 
     # Calculation of fraction of band's Planck irradiance associated with each g-point
-    do icol = 1, ncol
-      do ilay = 1, nlay
+    for icol in 1:ncol
+      for ilay in 1:nlay
         # itropo = 1 lower atmosphere; itropo = 2 upper atmosphere
-        itropo = merge(1,2,tropo(icol,ilay))
-        do ibnd = 1, nbnd
-          gptS = band_lims_gpt(1, ibnd)
-          gptE = band_lims_gpt(2, ibnd)
-          iflav = gpoint_flavor(itropo, gptS) #eta interpolation depends on band's flavor
-          pfrac(gptS:gptE,ilay,icol) = &
+        itropo = fmerge(1,2,tropo[icol,ilay])
+        for ibnd = 1, nbnd
+          gptS = band_lims_gpt[1, ibnd]
+          gptE = band_lims_gpt[2, ibnd]
+          iflav = gpoint_flavor[itropo, gptS] #eta interpolation depends on band's flavor
+          pfrac[gptS:gptE,ilay,icol] =
             # interpolation in temperature, pressure, and eta
-            interpolate3D_byflav(one, fmajor(:,:,:,iflav,icol,ilay), pfracin, &
-                          band_lims_gpt(1, ibnd), band_lims_gpt(2, ibnd),                 &
-                          jeta(:,iflav,icol,ilay), jtemp(icol,ilay),jpress(icol,ilay)+itropo)
-        end do # band
-      end do   # layer
-    end do     # column
+            interpolate3D_byflav(DT[1,1], fmajor[:,:,:,iflav,icol,ilay], pfracin,
+                          band_lims_gpt[1, ibnd], band_lims_gpt[2, ibnd],
+                          jeta[:,iflav,icol,ilay], jtemp[icol,ilay],jpress[icol,ilay]+itropo)
+        end # band
+      end   # layer
+    end     # column
 
     #
     # Planck function by band for the surface
     # Compute surface source irradiance for g-point, equals band irradiance x fraction for g-point
     #
-    do icol = 1, ncol
-      planck_function(1:nbnd,1,icol) = interpolate1D(tsfc(icol), temp_ref_min, totplnk_delta, totplnk)
+    for icol in 1:ncol
+      planck_function[1:nbnd,1,icol] = interpolate1D(tsfc[icol], temp_ref_min, totplnk_delta, totplnk)
       #
       # Map to g-points
       #
-      do ibnd = 1, nbnd
-        gptS = band_lims_gpt(1, ibnd)
-        gptE = band_lims_gpt(2, ibnd)
-        do igpt = gptS, gptE
-          sfc_src(igpt, icol) = pfrac(igpt,sfc_lay,icol) * planck_function(ibnd, 1, icol)
-        end do
-      end do
-    end do # icol
+      for ibnd in 1:nbnd
+        gptS = band_lims_gpt[1, ibnd]
+        gptE = band_lims_gpt[2, ibnd]
+        for igpt in gptS:gptE
+          sfc_src[igpt, icol] = pfrac[igpt,sfc_lay,icol] * planck_function[ibnd, 1, icol]
+        end
+      end
+    end # icol
 
-    do icol = 1, ncol
-      do ilay = 1, nlay
+    for icol in 1:ncol
+      for ilay in 1:nlay
         # Compute layer source irradiance for g-point, equals band irradiance x fraction for g-point
-        planck_function(1:nbnd,ilay,icol) = interpolate1D(tlay(icol,ilay), temp_ref_min, totplnk_delta, totplnk)
+        planck_function[1:nbnd,ilay,icol] = interpolate1D(tlay[icol,ilay], temp_ref_min, totplnk_delta, totplnk)
         #
         # Map to g-points
         #
-        do ibnd = 1, nbnd
-          gptS = band_lims_gpt(1, ibnd)
-          gptE = band_lims_gpt(2, ibnd)
-          do igpt = gptS, gptE
-            lay_src(igpt,ilay,icol) = pfrac(igpt,ilay,icol) * planck_function(ibnd,ilay,icol)
-          end do
-        end do
-      end do # ilay
-    end do # icol
+        for ibnd in 1:nbnd
+          gptS = band_lims_gpt[1, ibnd]
+          gptE = band_lims_gpt[2, ibnd]
+          for igpt in gptS:gptE
+            lay_src[igpt,ilay,icol] = pfrac[igpt,ilay,icol] * planck_function[ibnd,ilay,icol]
+          end
+        end
+      end # ilay
+    end # icol
 
     # compute level source irradiances for each g-point, one each for upward and downward paths
-    do icol = 1, ncol
-      planck_function(1:nbnd,       1,icol) = interpolate1D(tlev(icol,     1), temp_ref_min, totplnk_delta, totplnk)
-      do ilay = 1, nlay
-        planck_function(1:nbnd,ilay+1,icol) = interpolate1D(tlev(icol,ilay+1), temp_ref_min, totplnk_delta, totplnk)
+    for icol in 1:ncol
+      planck_function[1:nbnd,       1,icol] = interpolate1D(tlev[icol,     1], temp_ref_min, totplnk_delta, totplnk)
+      for ilay in 1:nlay
+        planck_function[1:nbnd,ilay+1,icol] = interpolate1D(tlev[icol,ilay+1], temp_ref_min, totplnk_delta, totplnk)
         #
         # Map to g-points
         #
-        do ibnd = 1, nbnd
-          gptS = band_lims_gpt(1, ibnd)
-          gptE = band_lims_gpt(2, ibnd)
-          do igpt = gptS, gptE
-            lev_src_inc(igpt,ilay,icol) = pfrac(igpt,ilay,icol) * planck_function(ibnd,ilay+1,icol)
-            lev_src_dec(igpt,ilay,icol) = pfrac(igpt,ilay,icol) * planck_function(ibnd,ilay,  icol)
-          end do
-        end do
-      end do # ilay
-    end do # icol
+        for ibnd in 1:nbnd
+          gptS = band_lims_gpt[1, ibnd]
+          gptE = band_lims_gpt[2, ibnd]
+          for igpt in gptS:gptE
+            lev_src_inc[igpt,ilay,icol] = pfrac[igpt,ilay,icol] * planck_function[ibnd,ilay+1,icol]
+            lev_src_dec[igpt,ilay,icol] = pfrac[igpt,ilay,icol] * planck_function[ibnd,ilay,  icol]
+          end
+        end
+      end # ilay
+    end # icol
 
-  end subroutine compute_Planck_source
-  # ----------------------------------------------------------
-  #
-  # One dimensional interpolation -- return all values along second table dimension
-  #
-  pure function interpolate1D(val, offset, delta, table) result(res)
-    # input
-    real(wp), intent(in) :: val,    & # axis value at which to evaluate table
-                            offset, & # minimum of table axis
-                            delta     # step size of table axis
-    real(wp), dimension(:,:), &
-              intent(in) :: table # dimensions (axis, values)
-    # output
-    real(wp), dimension(size(table,dim=2)) :: res
+  end
 
-    # local
-    real(wp) :: val0 # fraction index adjusted by offset and delta
-    integer :: index # index term
-    real(wp) :: frac # fractional term
-    # -------------------------------------
+"""
+    interpolate1D(...)
+
+One dimensional interpolation -- return all values along second table dimension
+
+
+# input
+real(wp), intent(in) :: val,     # axis value at which to evaluate table
+                        offset,  # minimum of table axis
+                        delta     # step size of table axis
+real(wp), dimension(:,:),
+          intent(in) :: table # dimensions (axis, values)
+# output
+real(wp), dimension(size(table,dim=2)) :: res
+
+# local
+real(wp) :: val0 # fraction index adjusted by offset and delta
+integer :: index # index term
+real(wp) :: frac # fractional term
+# -------------------------------------
+"""
+  function interpolate1D(val, offset, delta, table)
+    DT = eltype(delta)
+    res = Vector{DT}(undef, size(table, dim=2))
     val0 = (val - offset) / delta
     frac = val0 - int(val0) # get fractional part
     index = min(size(table,dim=1)-1, max(1, int(val0)+1)) # limit the index range
-    res(:) = table(index,:) + frac * (table(index+1,:) - table(index,:))
-  end function interpolate1D
-  # ----------------------------------------------------------------------------------------
-  #   This function returns a single value from a subset (in gpoint) of the k table
-  #
-  pure function interpolate2D(fminor, k, igpt, jeta, jtemp) result(res)
-    real(wp), dimension(2,2), intent(in) :: fminor # interpolation fractions for minor species
-                                       # index(1) : reference eta level (temperature dependent)
-                                       # index(2) : reference temperature level
-    real(wp), dimension(:,:,:), intent(in) :: k # (g-point, eta, temp)
-    integer,                    intent(in) :: igpt, jtemp # interpolation index for temperature
-    integer, dimension(2),      intent(in) :: jeta # interpolation index for binary species parameter (eta)
-    real(wp)                             :: res # the result
+    res[:] = table[index,:] + frac * (table[index+1,:] - table[index,:])
+    return res
+  end
 
-    res =  &
-      fminor(1,1) * k(igpt, jeta(1)  , jtemp  ) + &
-      fminor(2,1) * k(igpt, jeta(1)+1, jtemp  ) + &
-      fminor(1,2) * k(igpt, jeta(2)  , jtemp+1) + &
-      fminor(2,2) * k(igpt, jeta(2)+1, jtemp+1)
-  end function interpolate2D
-  # ----------------------------------------------------------
-  #   This function returns a range of values from a subset (in gpoint) of the k table
-  #
-  pure function interpolate2D_byflav(fminor, k, gptS, gptE, jeta, jtemp) result(res)
-    real(wp), dimension(2,2), intent(in) :: fminor # interpolation fractions for minor species
-                                       # index(1) : reference eta level (temperature dependent)
-                                       # index(2) : reference temperature level
-    real(wp), dimension(:,:,:), intent(in) :: k # (g-point, eta, temp)
-    integer,                    intent(in) :: gptS, gptE, jtemp # interpolation index for temperature
-    integer, dimension(2),      intent(in) :: jeta # interpolation index for binary species parameter (eta)
-    real(wp), dimension(gptE-gptS+1)       :: res # the result
+"""
+    interpolate2D(...)
 
-    # Local variable
-    integer :: igpt
-    # each code block is for a different reference temperature
-    do igpt = 1, gptE-gptS+1
-      res(igpt) = fminor(1,1) * k(gptS+igpt-1, jeta(1)  , jtemp  ) + &
-                  fminor(2,1) * k(gptS+igpt-1, jeta(1)+1, jtemp  ) + &
-                  fminor(1,2) * k(gptS+igpt-1, jeta(2)  , jtemp+1) + &
-                  fminor(2,2) * k(gptS+igpt-1, jeta(2)+1, jtemp+1)
-    end do
-  end function interpolate2D_byflav
-  # ----------------------------------------------------------
-  # interpolation in temperature, pressure, and eta
-  pure function interpolate3D(scaling, fmajor, k, igpt, jeta, jtemp, jpress) result(res)
-    real(wp), dimension(2),     intent(in) :: scaling
-    real(wp), dimension(2,2,2), intent(in) :: fmajor # interpolation fractions for major species
-                                                     # index(1) : reference eta level (temperature dependent)
-                                                     # index(2) : reference pressure level
-                                                     # index(3) : reference temperature level
-    real(wp), dimension(:,:,:,:),intent(in) :: k # (gpt, eta,temp,press)
-    integer,                     intent(in) :: igpt
-    integer, dimension(2),       intent(in) :: jeta # interpolation index for binary species parameter (eta)
-    integer,                     intent(in) :: jtemp # interpolation index for temperature
-    integer,                     intent(in) :: jpress # interpolation index for pressure
-    real(wp)                                :: res # the result
-    # each code block is for a different reference temperature
-    res =  &
-      scaling(1) * &
-      ( fmajor(1,1,1) * k(igpt, jeta(1)  , jpress-1, jtemp  ) + &
-        fmajor(2,1,1) * k(igpt, jeta(1)+1, jpress-1, jtemp  ) + &
-        fmajor(1,2,1) * k(igpt, jeta(1)  , jpress  , jtemp  ) + &
-        fmajor(2,2,1) * k(igpt, jeta(1)+1, jpress  , jtemp  ) ) + &
-      scaling(2) * &
-      ( fmajor(1,1,2) * k(igpt, jeta(2)  , jpress-1, jtemp+1) + &
-        fmajor(2,1,2) * k(igpt, jeta(2)+1, jpress-1, jtemp+1) + &
-        fmajor(1,2,2) * k(igpt, jeta(2)  , jpress  , jtemp+1) + &
-        fmajor(2,2,2) * k(igpt, jeta(2)+1, jpress  , jtemp+1) )
-  end function interpolate3D
-  # ----------------------------------------------------------
-  pure function interpolate3D_byflav(scaling, fmajor, k, gptS, gptE, jeta, jtemp, jpress) result(res)
-    real(wp), dimension(2),     intent(in) :: scaling
-    real(wp), dimension(2,2,2), intent(in) :: fmajor # interpolation fractions for major species
-                                                     # index(1) : reference eta level (temperature dependent)
-                                                     # index(2) : reference pressure level
-                                                     # index(3) : reference temperature level
-    real(wp), dimension(:,:,:,:),intent(in) :: k # (gpt, eta,temp,press)
-    integer,                     intent(in) :: gptS, gptE
-    integer, dimension(2),       intent(in) :: jeta # interpolation index for binary species parameter (eta)
-    integer,                     intent(in) :: jtemp # interpolation index for temperature
-    integer,                     intent(in) :: jpress # interpolation index for pressure
-    real(wp), dimension(gptE-gptS+1)        :: res # the result
+This function returns a single value from a subset (in gpoint) of the k table
 
-    # Local variable
-    integer :: igpt
+real(wp), dimension(2,2), intent(in) :: fminor # interpolation fractions for minor species
+                                   # index(1) : reference eta level (temperature dependent)
+                                   # index(2) : reference temperature level
+real(wp), dimension(:,:,:), intent(in) :: k # (g-point, eta, temp)
+integer,                    intent(in) :: igpt, jtemp # interpolation index for temperature
+integer, dimension(2),      intent(in) :: jeta # interpolation index for binary species parameter (eta)
+real(wp)                             :: res # the result
+"""
+  function interpolate2D(fminor, k, igpt, jeta, jtemp)
+    res =
+      fminor[1,1] * k[igpt, jeta[1]  , jtemp  ] +
+      fminor[2,1] * k[igpt, jeta[1]+1, jtemp  ] +
+      fminor[1,2] * k[igpt, jeta[2]  , jtemp+1] +
+      fminor[2,2] * k[igpt, jeta[2]+1, jtemp+1]
+    return res
+  end
+"""
+    interpolate2D_byflav(...)
+
+This function returns a range of values from a subset (in gpoint) of the k table
+
+real(wp), dimension(2,2), intent(in) :: fminor # interpolation fractions for minor species
+                                   # index(1) : reference eta level (temperature dependent)
+                                   # index(2) : reference temperature level
+real(wp), dimension(:,:,:), intent(in) :: k # (g-point, eta, temp)
+integer,                    intent(in) :: gptS, gptE, jtemp # interpolation index for temperature
+integer, dimension(2),      intent(in) :: jeta # interpolation index for binary species parameter (eta)
+real(wp), dimension(gptE-gptS+1)       :: res # the result
+
+# Local variable
+integer :: igpt
+"""
+  function interpolate2D_byflav(fminor, k, gptS, gptE, jeta, jtemp)
+    DT = eltype(fminor)
+    res = Vector{DT}(undef, gptE-gptS+1)
     # each code block is for a different reference temperature
-    do igpt = 1, gptE-gptS+1
-      res(igpt) =  &
-        scaling(1) * &
-        ( fmajor(1,1,1) * k(gptS+igpt-1, jeta(1)  , jpress-1, jtemp  ) + &
-          fmajor(2,1,1) * k(gptS+igpt-1, jeta(1)+1, jpress-1, jtemp  ) + &
-          fmajor(1,2,1) * k(gptS+igpt-1, jeta(1)  , jpress  , jtemp  ) + &
-          fmajor(2,2,1) * k(gptS+igpt-1, jeta(1)+1, jpress  , jtemp  ) ) + &
-        scaling(2) * &
-        ( fmajor(1,1,2) * k(gptS+igpt-1, jeta(2)  , jpress-1, jtemp+1) + &
-          fmajor(2,1,2) * k(gptS+igpt-1, jeta(2)+1, jpress-1, jtemp+1) + &
-          fmajor(1,2,2) * k(gptS+igpt-1, jeta(2)  , jpress  , jtemp+1) + &
-          fmajor(2,2,2) * k(gptS+igpt-1, jeta(2)+1, jpress  , jtemp+1) )
-    end do
-  end function interpolate3D_byflav
-  # ----------------------------------------------------------
-  #
-  # Combine absoprtion and Rayleigh optical depths for total tau, ssa, g
-  #
-  pure subroutine combine_and_reorder_2str(ncol, nlay, ngpt, tau_abs, tau_rayleigh, tau, ssa, g) &
-      bind(C, name="combine_and_reorder_2str")
-    integer,                             intent(in) :: ncol, nlay, ngpt
-    real(wp), dimension(ngpt,nlay,ncol), intent(in   ) :: tau_abs, tau_rayleigh
-    real(wp), dimension(ncol,nlay,ngpt), intent(inout) :: tau, ssa, g # inout because components are allocated
-    # -----------------------
-    integer  :: icol, ilay, igpt
-    real(wp) :: t
-    # -----------------------
-    do icol = 1, ncol
-      do ilay = 1, nlay
-        do igpt = 1, ngpt
-           t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol)
-           tau(icol,ilay,igpt) = t
-           g  (icol,ilay,igpt) = 0._wp
-           if(t > 2._wp * tiny(t)) then
-             ssa(icol,ilay,igpt) = tau_rayleigh(igpt,ilay,icol) / t
+    for igpt in 1:gptE-gptS+1
+      res[igpt] = fminor[1,1] * k[gptS+igpt-1, jeta[1]  , jtemp  ] +
+                  fminor[2,1] * k[gptS+igpt-1, jeta[1]+1, jtemp  ] +
+                  fminor[1,2] * k[gptS+igpt-1, jeta[2]  , jtemp+1] +
+                  fminor[2,2] * k[gptS+igpt-1, jeta[2]+1, jtemp+1]
+    end
+    return res
+  end
+
+"""
+    interpolate3D(...)
+
+interpolation in temperature, pressure, and eta
+
+real(wp), dimension(2),     intent(in) :: scaling
+real(wp), dimension(2,2,2), intent(in) :: fmajor # interpolation fractions for major species
+                                                 # index(1) : reference eta level (temperature dependent)
+                                                 # index(2) : reference pressure level
+                                                 # index(3) : reference temperature level
+real(wp), dimension(:,:,:,:),intent(in) :: k # (gpt, eta,temp,press)
+integer,                     intent(in) :: igpt
+integer, dimension(2),       intent(in) :: jeta # interpolation index for binary species parameter (eta)
+integer,                     intent(in) :: jtemp # interpolation index for temperature
+integer,                     intent(in) :: jpress # interpolation index for pressure
+real(wp)                                :: res # the result
+"""
+  function interpolate3D(scaling, fmajor, k, igpt, jeta, jtemp, jpress)
+    # each code block is for a different reference temperature
+    res =
+      scaling[1] *
+      ( fmajor[1,1,1] * k[igpt, jeta[1]  , jpress-1, jtemp  ] +
+        fmajor[2,1,1] * k[igpt, jeta[1]+1, jpress-1, jtemp  ] +
+        fmajor[1,2,1] * k[igpt, jeta[1]  , jpress  , jtemp  ] +
+        fmajor[2,2,1] * k[igpt, jeta[1]+1, jpress  , jtemp  ] ) +
+      scaling[2] *
+      ( fmajor[1,1,2] * k[igpt, jeta[2]  , jpress-1, jtemp+1] +
+        fmajor[2,1,2] * k[igpt, jeta[2]+1, jpress-1, jtemp+1] +
+        fmajor[1,2,2] * k[igpt, jeta[2]  , jpress  , jtemp+1] +
+        fmajor[2,2,2] * k[igpt, jeta[2]+1, jpress  , jtemp+1] )
+    return res
+  end
+
+"""
+    interpolate3D_byflav(...)
+
+real(wp), dimension(2),     intent(in) :: scaling
+real(wp), dimension(2,2,2), intent(in) :: fmajor # interpolation fractions for major species
+                                                 # index(1) : reference eta level (temperature dependent)
+                                                 # index(2) : reference pressure level
+                                                 # index(3) : reference temperature level
+real(wp), dimension(:,:,:,:),intent(in) :: k # (gpt, eta,temp,press)
+integer,                     intent(in) :: gptS, gptE
+integer, dimension(2),       intent(in) :: jeta # interpolation index for binary species parameter (eta)
+integer,                     intent(in) :: jtemp # interpolation index for temperature
+integer,                     intent(in) :: jpress # interpolation index for pressure
+real(wp), dimension(gptE-gptS+1)        :: res # the result
+
+# Local variable
+integer :: igpt
+"""
+
+  function interpolate3D_byflav(scaling, fmajor, k, gptS, gptE, jeta, jtemp, jpress)
+    # each code block is for a different reference temperature
+    DT = eltype(k)
+    res = Vector{DT}(undef, gptE-gptS+1)
+    for igpt = 1, gptE-gptS+1
+      res[igpt] =
+        scaling[1] *
+        ( fmajor[1,1,1] * k[gptS+igpt-1, jeta[1]  , jpress-1, jtemp  ] +
+          fmajor[2,1,1] * k[gptS+igpt-1, jeta[1]+1, jpress-1, jtemp  ] +
+          fmajor[1,2,1] * k[gptS+igpt-1, jeta[1]  , jpress  , jtemp  ] +
+          fmajor[2,2,1] * k[gptS+igpt-1, jeta[1]+1, jpress  , jtemp  ] ) +
+        scaling[2] *
+        ( fmajor[1,1,2] * k[gptS+igpt-1, jeta[2]  , jpress-1, jtemp+1] +
+          fmajor[2,1,2] * k[gptS+igpt-1, jeta[2]+1, jpress-1, jtemp+1] +
+          fmajor[1,2,2] * k[gptS+igpt-1, jeta[2]  , jpress  , jtemp+1] +
+          fmajor[2,2,2] * k[gptS+igpt-1, jeta[2]+1, jpress  , jtemp+1] )
+    end
+    return res
+  end
+
+"""
+    combine_and_reorder_2str!(...)
+
+Combine absoprtion and Rayleigh optical depths for total tau, ssa, g
+
+integer,                             intent(in) :: ncol, nlay, ngpt
+real(wp), dimension(ngpt,nlay,ncol), intent(in   ) :: tau_abs, tau_rayleigh
+real(wp), dimension(ncol,nlay,ngpt), intent(inout) :: tau, ssa, g # inout because components are allocated
+# -----------------------
+integer  :: icol, ilay, igpt
+real(wp) :: t
+# -----------------------
+"""
+  function combine_and_reorder_2str!(ncol, nlay, ngpt, tau_abs, tau_rayleigh, tau, ssa, g)
+    DT = eltype(tau_abs)
+    for icol in 1:ncol
+      for ilay in 1:nlay
+        for igpt in 1:ngpt
+           t = tau_abs[igpt,ilay,icol] + tau_rayleigh[igpt,ilay,icol]
+           tau[icol,ilay,igpt] = t
+           g  (icol,ilay,igpt) = DT(0)
+           if (t > DT(2) * realmin(DT))
+             ssa[icol,ilay,igpt] = tau_rayleigh[igpt,ilay,icol] / t
            else
-             ssa(icol,ilay,igpt) = 0._wp
-           end if
-        end do
-      end do
-    end do
-  end subroutine combine_and_reorder_2str
-  # ----------------------------------------------------------
-  #
-  # Combine absoprtion and Rayleigh optical depths for total tau, ssa, p
-  #   using Rayleigh scattering phase function
-  #
-  pure subroutine combine_and_reorder_nstr(ncol, nlay, ngpt, nmom, tau_abs, tau_rayleigh, tau, ssa, p) &
-      bind(C, name="combine_and_reorder_nstr")
-    integer, intent(in) :: ncol, nlay, ngpt, nmom
-    real(wp), dimension(ngpt,nlay,ncol), intent(in ) :: tau_abs, tau_rayleigh
-    real(wp), dimension(ncol,nlay,ngpt), intent(inout) :: tau, ssa
-    real(wp), dimension(ncol,nlay,ngpt,nmom), &
-                                         intent(inout) :: p
-    # -----------------------
-    integer :: icol, ilay, igpt, imom
-    real(wp) :: t
-    # -----------------------
-    do icol = 1, ncol
-      do ilay = 1, nlay
-        do igpt = 1, ngpt
-          t = tau_abs(igpt,ilay,icol) + tau_rayleigh(igpt,ilay,icol)
-          tau(icol,ilay,igpt) = t
-          if(t > 2._wp * tiny(t)) then
-            ssa(icol,ilay,igpt) = tau_rayleigh(igpt,ilay,icol) / t
+             ssa[icol,ilay,igpt] = DT(0)
+           end
+        end
+      end
+    end
+  end
+
+"""
+    combine_and_reorder_nstr!(...)
+
+Combine absoprtion and Rayleigh optical depths for total tau, ssa, p
+using Rayleigh scattering phase function
+
+integer, intent(in) :: ncol, nlay, ngpt, nmom
+real(wp), dimension(ngpt,nlay,ncol), intent(in ) :: tau_abs, tau_rayleigh
+real(wp), dimension(ncol,nlay,ngpt), intent(inout) :: tau, ssa
+real(wp), dimension(ncol,nlay,ngpt,nmom),
+                                     intent(inout) :: p
+# -----------------------
+integer :: icol, ilay, igpt, imom
+real(wp) :: t
+# -----------------------
+"""
+  function combine_and_reorder_nstr!(ncol, nlay, ngpt, nmom, tau_abs, tau_rayleigh, tau, ssa, p)
+    DT = eltype(tau_abs)
+
+    for icol in 1:ncol
+      for ilay in 1:nlay
+        for igpt in 1:ngpt
+          t = tau_abs[igpt,ilay,icol] + tau_rayleigh[igpt,ilay,icol]
+          tau[icol,ilay,igpt] = t
+          if (t > DT(2) * realmin(DT))
+            ssa[icol,ilay,igpt] = tau_rayleigh[igpt,ilay,icol] / t
           else
-            ssa(icol,ilay,igpt) = 0._wp
-          end if
-          do imom = 1, nmom
-            p(imom,icol,ilay,igpt) = 0.0_wp
-          end do
-          if(nmom >= 2) p(2,icol,ilay,igpt) = 0.1_wp
-        end do
-      end do
-    end do
-  end subroutine combine_and_reorder_nstr
+            ssa[icol,ilay,igpt] = DT(0)
+          end
+          for imom = 1:nmom
+            p[imom,icol,ilay,igpt] = DT(0)
+          end
+          if (nmom >= 2) p[2,icol,ilay,igpt] = DT(0.1)
+        end
+      end
+    end
+  end
 end module mo_gas_optics_kernels


### PR DESCRIPTION
Translated `mo_gas_optics_kernels`. @simonbyrne Here's the first file, but I know that [these lines](https://github.com/climate-machine/JRRTMGP/compare/mo_gas_optics_kernels?expand=1#diff-1c93cf0a86d4fa31e1075997f837afacR23-R45) need to be tested/fixed, for at the very least edge cases (e.g., the case of `any(mask) = false`).