### PR TITLE
Translate mo_rrtmgp_constants

### DIFF
--- a/src/rrtmgp/mo_rrtmgp_constants.jl
+++ b/src/rrtmgp/mo_rrtmgp_constants.jl
@@ -20,22 +20,30 @@
 #   host model but may be changed in a call to init_constants(), normally at initialization
 # -------------------------------------------------------------------------------------------------
 module mo_rrtmgp_constants
-  use mo_rte_kind, only: wp
+  # use mo_rte_kind, only: wp
+
+  export k_boltz,
+         m_h2o,
+         avogad,
+         R_univ_gconst,
+         m_dry,
+         grav,
+         cp_dry
 
   # -----------------------------------------
   # Physical constants, 2018 SI defintion of metric system
   #   doi:10.1088/1681-7575/aa950a (see also https://www.nist.gov/si-redefinition/meet-constants)
   # Boltzmann constant [J/K] = [(kg m^2)/(K s^2)]
-  real(wp), parameter :: k_boltz = 1.380649e-23_wp
+  k_boltz(::Type{DT}) where DT = DT(1.380649e-23)
 
   #  molecular weight of water [kg/mol]
-  real(wp), parameter :: m_h2o =  0.018016_wp
+  m_h2o(::Type{DT}) where DT = DT( 0.018016)
 
   # Avogadro's number [molec/mol]
-  real(wp), parameter :: avogad = 6.02214076e23_wp
+  avogad(::Type{DT}) where DT = DT(6.02214076e23)
 
   # Universal gas constant [J/(mol K)]
-  real(wp), parameter :: R_univ_gconst = avogad * k_boltz
+  R_univ_gconst(::Type{DT}) where DT = DT(avogad * k_boltz)
 
   # -----------------------------------------
   #
@@ -43,23 +51,12 @@ module mo_rrtmgp_constants
   #   might be different on e.g. other planets
 
   # molecular weight of dry air [kg/mol]
-  real(wp), protected :: m_dry = 0.028964_wp
+  m_dry(::Type{DT}) where DT = DT(0.028964)
 
   # Gravity at Earth's surface [m/s2]
-  real(wp), protected :: grav = 9.80665_wp
+  grav(::Type{DT}) where DT = DT(9.80665)
 
   # Specific heat at constant pressure for dry air [J/(K kg)]
-  real(wp), protected :: cp_dry = 1004.64_wp
+  cp_dry(::Type{DT}) where DT = DT(1004.64)
 
-contains
-  # -----------------------------------------
-  subroutine init_constants(gravity, mol_weight_dry_air, heat_capacity_dry_air)
-    real(wp), optional, intent(in) :: gravity, mol_weight_dry_air, heat_capacity_dry_air
-
-    if(present(gravity))               grav   = gravity
-    if(present(mol_weight_dry_air))    m_dry  = mol_weight_dry_air
-    if(present(heat_capacity_dry_air)) cp_dry = heat_capacity_dry_air
-
-  end subroutine init_constants
-  # -----------------------------------------
-end module mo_rrtmgp_constants
+end


### PR DESCRIPTION
Translates `mo_rrtmgp_constants`
Note that `init_constants` was removed since it is never called