### PR TITLE
Add shortwave test with alternative optical props

### DIFF
--- a/src/rrtmgp/mo_gas_optics_rrtmgp.jl
+++ b/src/rrtmgp/mo_gas_optics_rrtmgp.jl
@@ -137,7 +137,7 @@ function gas_optics_int!(this::ty_gas_optics_rrtmgp,
   jpress = Array{Int}(undef, size(play))
   jtemp = Array{Int}(undef, size(play))
   tropo = Array{Bool}(undef, size(play))
-  fmajor = Array{FT}(undef, 2,2,2,get_nflav(this),size(play)...)
+  fmajor = zeros(FT, 2,2,2,get_nflav(this),size(play)...)
   jeta = Array{Int}(undef, 2,    get_nflav(this), size(play)...)
 
   ncol  = size(play, 1)
@@ -217,7 +217,7 @@ function gas_optics_ext!(this::ty_gas_optics_rrtmgp,
   jpress = Array{Int}( undef, size(play))
   jtemp  = Array{Int}( undef, size(play))
   tropo  = Array{Bool}(undef, size(play))
-  fmajor = Array{FT}(  undef, 2,2,2, get_nflav(this), size(play)...)
+  fmajor = zeros(FT, 2,2,2, get_nflav(this), size(play)...)
   jeta   = Array{Int}( undef, 2,     get_nflav(this), size(play)...)
 
   ncol  = size(play, 1)
@@ -302,15 +302,15 @@ function compute_gas_taus!(this::ty_gas_optics_rrtmgp,
                           col_dry=nothing)
 
   FT = eltype(play)
-  tau = Array{FT}(undef, ngpt,nlay,ncol)          # absorption, Rayleigh scattering optical depths
-  tau_rayleigh = Array{FT}(undef, ngpt,nlay,ncol) # absorption, Rayleigh scattering optical depths
-  col_dry_arr = Array{FT}(undef, ncol, nlay)
-  col_dry_wk = Array{FT}(undef, ncol, nlay)
+  tau          = zeros(FT, ngpt,nlay,ncol)          # absorption, Rayleigh scattering optical depths
+  tau_rayleigh = zeros(FT, ngpt,nlay,ncol) # absorption, Rayleigh scattering optical depths
+  col_dry_arr  = zeros(FT, ncol, nlay)
+  col_dry_wk   = zeros(FT, ncol, nlay)
 
-  vmr     = Array{FT}(undef, ncol,nlay,  get_ngas(this)) # volume mixing ratios
+  vmr     = zeros(FT, ncol,nlay,  get_ngas(this)) # volume mixing ratios
   col_gas = OffsetArray{FT}(undef, 1:ncol,1:nlay,0:get_ngas(this)) # column amounts for each gas, plus col_dry
-  col_mix = Array{FT}(undef, 2,    get_nflav(this),ncol,nlay) # combination of major species's column amounts
-  fminor  = Array{FT}(undef, 2,2,  get_nflav(this),ncol,nlay) # interpolation fractions for minor species
+  col_mix = zeros(FT, 2,    get_nflav(this),ncol,nlay) # combination of major species's column amounts
+  fminor  = zeros(FT, 2,2,  get_nflav(this),ncol,nlay) # interpolation fractions for minor species
 
   # Error checking
   use_rayl = allocated(this.krayl)
@@ -473,11 +473,11 @@ function source(this::ty_gas_optics_rrtmgp,
                 tlev)                                # optional input
   FT = eltype(this.vmr_ref) # Float64
 
-  lay_source_t = Array{FT}(undef, ngpt,nlay,ncol)
-  lev_source_inc_t = Array{FT}(undef, ngpt,nlay,ncol)
-  lev_source_dec_t = Array{FT}(undef, ngpt,nlay,ncol)
-  sfc_source_t = Array{FT}(undef, ngpt,ncol)
-  tlev_arr = Array{FT}(undef, ncol,nlay+1)
+  lay_source_t     = zeros(FT, ngpt,nlay,ncol)
+  lev_source_inc_t = zeros(FT, ngpt,nlay,ncol)
+  lev_source_dec_t = zeros(FT, ngpt,nlay,ncol)
+  sfc_source_t     = zeros(FT, ngpt,ncol)
+  tlev_arr         = zeros(FT, ncol,nlay+1)
 
   # Source function needs temperature at interfaces/levels and at layer centers
   if present(tlev)
@@ -731,7 +731,7 @@ kminor_start_lower
   @assert allocated(rayl_lower) == allocated(rayl_upper)
 
   if allocated(rayl_lower)
-    this.krayl = Array{FT}(undef, size(rayl_lower,1),size(rayl_lower,2),size(rayl_lower,3),2)
+    this.krayl = zeros(FT, size(rayl_lower,1),size(rayl_lower,2),size(rayl_lower,3),2)
     this.krayl[:,:,:,1] = rayl_lower
     this.krayl[:,:,:,2] = rayl_upper
   end
@@ -912,9 +912,9 @@ function get_col_dry(vmr_h2o, plev, tlay, latitude=nothing)
   helmert1 = FT(9.80665)
   helmert2 = FT(0.02586)
   # local variables
-  g0         = Array{FT}(undef, size(tlay,1)             ) # (ncol)
-  delta_plev = Array{FT}(undef, size(tlay,1),size(tlay,2)) # (ncol,nlay)
-  m_air      = Array{FT}(undef, size(tlay,1),size(tlay,2)) # average mass of air; (ncol,nlay)
+  g0         = zeros(FT, size(tlay,1)             ) # (ncol)
+  delta_plev = zeros(FT, size(tlay,1),size(tlay,2)) # (ncol,nlay)
+  m_air      = zeros(FT, size(tlay,1),size(tlay,2)) # average mass of air; (ncol,nlay)
   # integer :: nlev, nlay
   # ------------------------------------------------
   nlay = size(tlay, 2)
@@ -931,7 +931,7 @@ function get_col_dry(vmr_h2o, plev, tlay, latitude=nothing)
   m_air[:,:] .= (m_dry(FT) .+ m_h2o(FT) .* vmr_h2o[:,:]) ./ (1 .+ vmr_h2o[:,:])
 
   # Hydrostatic equation
-  col_dry = Array{FT}(undef, size(tlay,1),size(tlay,2))
+  col_dry = zeros(FT, size(tlay,1),size(tlay,2))
   col_dry[:,:] .= FT(10) .* delta_plev[:,:] .* avogad(FT) ./ (FT(1000)*m_air[:,:] .* FT(100) .* spread(g0[:], 2, nlay))
   col_dry[:,:] .= col_dry[:,:] ./ (FT(1) .+ vmr_h2o[:,:])
   return col_dry
@@ -1175,7 +1175,7 @@ kminor_start_atm
       gas_is_present)
 
     minor_limits_gpt_atm_red = Array{Int}(undef, 2, red_nm)
-    kminor_atm_red = Array{FT}(undef, tot_g, size(kminor_atm,2), size(kminor_atm,3))
+    kminor_atm_red = zeros(FT, tot_g, size(kminor_atm,2), size(kminor_atm,3))
 
     icnt = 0
     n_elim = 0

--- a/src/rte/kernels/mo_rte_solver_kernels.jl
+++ b/src/rte/kernels/mo_rte_solver_kernels.jl
@@ -310,6 +310,7 @@ real(FT) :: mu0_inv(ncol)
 function sw_solver_noscat!(ncol, nlay, ngpt,
                               top_at_1, tau::Array{FT}, mu0, flux_dir) where FT
 
+  mu0_inv = Vector{FT}(undef, ncol)
   mu0_inv[1:ncol] .= FT(1) ./ mu0[1:ncol]
   # Indexing into arrays for upward and downward propagation depends on the vertical
   #   orientation of the arrays (whether the domain top is at the first or last index)
@@ -323,7 +324,7 @@ function sw_solver_noscat!(ncol, nlay, ngpt,
     # previous level is up (-1)
     for igpt in 1:ngpt
       for ilev in 2:nlay+1
-        flux_dir[:,ilev,igpt] .= flux_dir[:,ilev-1,igpt] .* exp(-tau[:,ilev-1,igpt]*mu0_inv[:])
+        flux_dir[:,ilev,igpt] .= flux_dir[:,ilev-1,igpt] .* exp.(-tau[:,ilev-1,igpt].*mu0_inv[:])
       end
     end
   else
@@ -331,7 +332,7 @@ function sw_solver_noscat!(ncol, nlay, ngpt,
     # previous level is up (+1)
     for igpt in 1:ngpt
       for ilev in nlay:-1:1
-        flux_dir[:,ilev,igpt] .= flux_dir[:,ilev+1,igpt] .* exp(-tau[:,ilev,igpt]*mu0_inv[:])
+        flux_dir[:,ilev,igpt] .= flux_dir[:,ilev+1,igpt] .* exp.(-tau[:,ilev,igpt].*mu0_inv[:])
       end
     end
   end

--- a/src/rte/kernels/mo_rte_solver_kernels.jl
+++ b/src/rte/kernels/mo_rte_solver_kernels.jl
@@ -82,12 +82,12 @@ function lw_solver_noscat!(ncol, nlay, ngpt, top_at_1, D, weight,
                               tau, lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src,
                               radn_up, radn_dn)
   FT         = eltype(tau)
-  tau_loc    = Array{FT}(undef,ncol,nlay)
-  trans      = Array{FT}(undef,ncol,nlay)
-  source_up  = Array{FT}(undef,ncol,nlay)
-  source_dn  = Array{FT}(undef,ncol,nlay)
-  source_sfc = Array{FT}(undef,ncol)
-  sfc_albedo = Array{FT}(undef,ncol)
+  tau_loc    = zeros(FT,ncol,nlay)
+  trans      = zeros(FT,ncol,nlay)
+  source_up  = zeros(FT,ncol,nlay)
+  source_dn  = zeros(FT,ncol,nlay)
+  source_sfc = zeros(FT,ncol)
+  sfc_albedo = zeros(FT,ncol)
   # Which way is up?
   # Level Planck sources for upward and downward radiation
   # When top_at_1, lev_source_up => lev_source_dec
@@ -178,7 +178,7 @@ function lw_solver_noscat_GaussQuad!(ncol, nlay, ngpt, top_at_1, nmus, Ds, weigh
   # For the first angle output arrays store total flux
   #
   FT = eltype(tau)
-  Ds_ncol = Array{FT}(undef,ncol,ngpt)
+  Ds_ncol = zeros(FT,ncol,ngpt)
 
   Ds_ncol .= Ds[1]
   lw_solver_noscat!(ncol, nlay, ngpt,
@@ -242,12 +242,12 @@ function lw_solver_2stream!(ncol, nlay, ngpt, top_at_1,
                                lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src,
                                flux_up, flux_dn)
   FT = eltype(tau)
-  lev_source = Array{FT}(undef, ncol,nlay+1)
-  source_sfc = Array{FT}(undef, ncol)
-  source_dn = Array{FT}(undef, ncol, nlay)
-  source_up = Array{FT}(undef, ncol, nlay)
-  sfc_albedo = Array{FT}(undef, ncol)
-  Rdif, Tdif, gamma1, gamma2 = ntuple(i->Array{FT}(undef, ncol, nlay),4)
+  lev_source = zeros(FT, ncol,nlay+1)
+  source_sfc = zeros(FT, ncol)
+  source_dn = zeros(FT, ncol, nlay)
+  source_up = zeros(FT, ncol, nlay)
+  sfc_albedo = zeros(FT, ncol)
+  Rdif, Tdif, gamma1, gamma2 = ntuple(i->zeros(FT, ncol, nlay),4)
   for igpt in 1:ngpt
     #
     # RRTMGP provides source functions at each level using the spectral mapping
@@ -371,8 +371,8 @@ function sw_solver_2stream!(ncol, nlay, ngpt, top_at_1,
                                  sfc_alb_dir, sfc_alb_dif,
                                  flux_up, flux_dn, flux_dir) where FT
 
-  Rdif, Tdif, Rdir, Tdir, Tnoscat, source_up, source_dn = ntuple(i->Array{FT}(undef, ncol,nlay), 7)
-  source_srf = Array{FT}(undef, ncol)
+  Rdif, Tdif, Rdir, Tdir, Tnoscat, source_up, source_dn = ntuple(i->zeros(FT, ncol,nlay), 7)
+  source_srf = zeros(FT, ncol)
 
   for igpt in 1:ngpt
     #
@@ -746,13 +746,13 @@ end
 function sw_two_stream(ncol, nlay, mu0, tau, w0, g)
   FT = eltype(tau)
   mu0_inv = 1 ./ mu0
-  exp_minusktau = Array{FT}(undef, ncol)
-  exp_minus2ktau = Array{FT}(undef, ncol)
-  RT_term = Array{FT}(undef, ncol)
+  exp_minusktau = zeros(FT, ncol)
+  exp_minus2ktau = zeros(FT, ncol)
+  RT_term = zeros(FT, ncol)
 
-  Rdif, Tdif, Rdir, Tdir, Tnoscat = ntuple(i-> Array{FT}(undef, ncol,nlay), 5)
+  Rdif, Tdif, Rdir, Tdir, Tnoscat = ntuple(i-> zeros(FT, ncol,nlay), 5)
 
-  gamma1, gamma2, gamma3, gamma4, alpha1, alpha2, k = ntuple(i->Array{FT}(undef, ncol), 7)
+  gamma1, gamma2, gamma3, gamma4, alpha1, alpha2, k = ntuple(i->zeros(FT, ncol), 7)
 
   for j in 1:nlay
     for i in 1:ncol
@@ -915,9 +915,9 @@ function adding!(ncol, nlay, top_at_1,
                   src_dn, src_up, src_sfc,
                   flux_up, flux_dn)
   FT = eltype(albedo_sfc)
-  albedo = Array{FT}(undef, ncol,nlay+1)
-  src = Array{FT}(undef, ncol,nlay+1)
-  denom = Array{FT}(undef, ncol,nlay)
+  albedo = zeros(FT, ncol,nlay+1)
+  src = zeros(FT, ncol,nlay+1)
+  denom = zeros(FT, ncol,nlay)
   #
   # Indexing into arrays for upward and downward propagation depends on the vertical
   #   orientation of the arrays (whether the domain top is at the first or last index)
@@ -1023,7 +1023,7 @@ function apply_BC(ncol::I, nlay::I, ngpt::I,
                    top_at_1::B,
                    inc_flux::Array{FT,2}) where {I<:Integer,B<:Bool,FT}
   #   Upper boundary condition
-  flux_dn = Array{FT}(undef, ncol,nlay+1,ngpt)
+  flux_dn = zeros(FT, ncol,nlay+1,ngpt)
   fill!(flux_dn, 0)
   if top_at_1
     flux_dn[1:ncol,      1, 1:ngpt]  .= inc_flux[1:ncol,1:ngpt]
@@ -1047,7 +1047,7 @@ function apply_BC(ncol::I, nlay::I, ngpt::I,
                    inc_flux::Array{FT,2},
                    factor::Array{FT,1}) where {I<:Integer,B<:Bool,FT}
   #   Upper boundary condition
-  flux_dn = Array{FT}(undef, ncol,nlay+1,ngpt)
+  flux_dn = zeros(FT, ncol,nlay+1,ngpt)
   # flux_dn = zeros(FT, ncol,nlay+1,ngpt)
   fill!(flux_dn, 0)
   if top_at_1
@@ -1070,7 +1070,7 @@ end
 function apply_BC(ncol::I, nlay::I, ngpt::I,
                    top_at_1::B, FT) where {I<:Integer,B<:Bool}
   #   Upper boundary condition
-  flux_dn = Array{FT}(undef, ncol,nlay+1,ngpt)
+  flux_dn = zeros(FT, ncol,nlay+1,ngpt)
   if top_at_1
     # flux_dn[1:ncol,      1, 1:ngpt]  .= FT(0)
     flux_dn .= FT(0)

--- a/src/rte/kernels/mo_rte_solver_kernels.jl
+++ b/src/rte/kernels/mo_rte_solver_kernels.jl
@@ -1,16 +1,5 @@
 """
-
-This code is part of Radiative Transfer for Energetics (RTE)
-
-Contacts: Robert Pincus and Eli Mlawer
-email:  rrtmgp@aer.com
-
-Copyright 2015-2018,  Atmospheric and Environmental Research and
-Regents of the University of Colorado.  All right reserved.
-
-Use and duplication is permitted under the terms of the
-  BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
--------------------------------------------------------------------------------------------------
+    mo_rte_solver_kernels
 
 Numeric calculations for radiative transfer solvers.
  Emission/absorption (no-scattering) calculations
@@ -25,8 +14,6 @@ Numeric calculations for radiative transfer solvers.
      two-stream calculations for LW, SW (using different assumptions about phase function)
      transport (adding)
  Application of boundary conditions
-
--------------------------------------------------------------------------------------------------
 """
 module mo_rte_solver_kernels
 
@@ -94,66 +81,66 @@ integer             :: ilev, igpt, top_level
 function lw_solver_noscat!(ncol, nlay, ngpt, top_at_1, D, weight,
                               tau, lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src,
                               radn_up, radn_dn)
-    FT         = eltype(tau)
-    tau_loc    = Array{FT}(undef,ncol,nlay)
-    trans      = Array{FT}(undef,ncol,nlay)
-    source_up  = Array{FT}(undef,ncol,nlay)
-    source_dn  = Array{FT}(undef,ncol,nlay)
-    source_sfc = Array{FT}(undef,ncol)
-    sfc_albedo = Array{FT}(undef,ncol)
-    # Which way is up?
-    # Level Planck sources for upward and downward radiation
-    # When top_at_1, lev_source_up => lev_source_dec
-    #                lev_source_dn => lev_source_inc, and vice-versa
-    if top_at_1
-      top_level = 1
-      lev_source_up = lev_source_dec
-      lev_source_dn = lev_source_inc
-    else
-      top_level = nlay+1
-      lev_source_up = lev_source_inc
-      lev_source_dn = lev_source_dec
-    end
-
-    for igpt in 1:ngpt
-      #
-      # Transport is for intensity
-      #   convert flux at top of domain to intensity assuming azimuthal isotropy
-      #
-      radn_dn[:,top_level,igpt] .= radn_dn[:,top_level,igpt]./(FT(2) * π * weight)
-
-      #
-      # Optical path and transmission, used in source function and transport calculations
-      #
-      for ilev in 1:nlay
-        tau_loc[:,ilev] .= tau[:,ilev,igpt] .* D[:,igpt]
-        trans[:,ilev]   .= exp.(-tau_loc[:,ilev])
-      end
-      #
-      # Source function for diffuse radiation
-      #
-      lw_source_noscat!(ncol, nlay,
-                            lay_source[:,:,igpt], lev_source_up[:,:,igpt], lev_source_dn[:,:,igpt],
-                            tau_loc, trans, source_dn, source_up)
-      #
-      # Surface albedo, surface source function
-      #
-      sfc_albedo .= FT(1) .- sfc_emis[:,igpt]
-      source_sfc .= sfc_emis[:,igpt] .* sfc_src[:,igpt]
-      #
-      # Transport
-      #
-      lw_transport_noscat!(ncol, nlay, top_at_1,
-                               tau_loc, trans, sfc_albedo, source_dn, source_up, source_sfc,
-                               @view(radn_up[:,:,igpt]), @view(radn_dn[:,:,igpt]))
-      #
-      # Convert intensity to flux assuming azimuthal isotropy and quadrature weight
-      #
-      radn_dn[:,:,igpt] .= FT(2) * π * weight .* radn_dn[:,:,igpt]
-      radn_up[:,:,igpt] .= FT(2) * π * weight .* radn_up[:,:,igpt]
-    end  # g point loop
-
+  FT         = eltype(tau)
+  tau_loc    = Array{FT}(undef,ncol,nlay)
+  trans      = Array{FT}(undef,ncol,nlay)
+  source_up  = Array{FT}(undef,ncol,nlay)
+  source_dn  = Array{FT}(undef,ncol,nlay)
+  source_sfc = Array{FT}(undef,ncol)
+  sfc_albedo = Array{FT}(undef,ncol)
+  # Which way is up?
+  # Level Planck sources for upward and downward radiation
+  # When top_at_1, lev_source_up => lev_source_dec
+  #                lev_source_dn => lev_source_inc, and vice-versa
+  if top_at_1
+    top_level = 1
+    lev_source_up = lev_source_dec
+    lev_source_dn = lev_source_inc
+  else
+    top_level = nlay+1
+    lev_source_up = lev_source_inc
+    lev_source_dn = lev_source_dec
   end
+
+  for igpt in 1:ngpt
+    #
+    # Transport is for intensity
+    #   convert flux at top of domain to intensity assuming azimuthal isotropy
+    #
+    radn_dn[:,top_level,igpt] .= radn_dn[:,top_level,igpt]./(FT(2) * π * weight)
+
+    #
+    # Optical path and transmission, used in source function and transport calculations
+    #
+    for ilev in 1:nlay
+      tau_loc[:,ilev] .= tau[:,ilev,igpt] .* D[:,igpt]
+      trans[:,ilev]   .= exp.(-tau_loc[:,ilev])
+    end
+    #
+    # Source function for diffuse radiation
+    #
+    lw_source_noscat!(ncol, nlay,
+                          lay_source[:,:,igpt], lev_source_up[:,:,igpt], lev_source_dn[:,:,igpt],
+                          tau_loc, trans, source_dn, source_up)
+    #
+    # Surface albedo, surface source function
+    #
+    sfc_albedo .= FT(1) .- sfc_emis[:,igpt]
+    source_sfc .= sfc_emis[:,igpt] .* sfc_src[:,igpt]
+    #
+    # Transport
+    #
+    lw_transport_noscat!(ncol, nlay, top_at_1,
+                             tau_loc, trans, sfc_albedo, source_dn, source_up, source_sfc,
+                             @view(radn_up[:,:,igpt]), @view(radn_dn[:,:,igpt]))
+    #
+    # Convert intensity to flux assuming azimuthal isotropy and quadrature weight
+    #
+    radn_dn[:,:,igpt] .= FT(2) * π * weight .* radn_dn[:,:,igpt]
+    radn_up[:,:,igpt] .= FT(2) * π * weight .* radn_up[:,:,igpt]
+  end  # g point loop
+
+end
 
 """
     lw_solver_noscat_GaussQuad!(...)
@@ -186,34 +173,35 @@ integer :: imu, top_level
 function lw_solver_noscat_GaussQuad!(ncol, nlay, ngpt, top_at_1, nmus, Ds, weights,
                                    tau, lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src, flux_up, flux_dn)
 
-    # ------------------------------------
-    #
-    # For the first angle output arrays store total flux
-    #
-    FT = eltype(tau)
-    Ds_ncol = Array{FT}(undef,ncol,ngpt)
+  # ------------------------------------
+  #
+  # For the first angle output arrays store total flux
+  #
+  FT = eltype(tau)
+  Ds_ncol = Array{FT}(undef,ncol,ngpt)
 
-    Ds_ncol .= Ds[1]
+  Ds_ncol .= Ds[1]
+  lw_solver_noscat!(ncol, nlay, ngpt,
+                    top_at_1, Ds_ncol, weights[1], tau,
+                    lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src,
+                    flux_up, flux_dn)
+  #
+  # For more than one angle use local arrays
+  #
+  top_level = fmerge(1, nlay+1, top_at_1)
+  radn_dn = apply_BC(ncol, nlay, ngpt, top_at_1, flux_dn[:,top_level,:])
+
+  for imu in 2:nmus
+    Ds_ncol .= Ds[imu]
     lw_solver_noscat!(ncol, nlay, ngpt,
-                      top_at_1, Ds_ncol, weights[1], tau,
+                      top_at_1, Ds_ncol, weights[imu], tau,
                       lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src,
-                      flux_up, flux_dn)
-    #
-    # For more than one angle use local arrays
-    #
-    top_level = fmerge(1, nlay+1, top_at_1)
-    radn_dn = apply_BC(ncol, nlay, ngpt, top_at_1, flux_dn[:,top_level,:])
-
-    for imu in 2:nmus
-      Ds_ncol .= Ds[imu]
-      lw_solver_noscat!(ncol, nlay, ngpt,
-                        top_at_1, Ds_ncol, weights[imu], tau,
-                        lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src,
-                        radn_up, radn_dn)
-      flux_up .+= radn_up
-      flux_dn .+= radn_dn
-    end
+                      radn_up, radn_dn)
+    flux_up .+= radn_up
+    flux_dn .+= radn_dn
   end
+end
+
 """
     lw_solver_2stream!(...)
 
@@ -249,52 +237,53 @@ real(FT), dimension(ncol,nlay  ) :: source_dn, source_up
 real(FT), dimension(ncol       ) :: source_sfc
 # ------------------------------------
 """
- function lw_solver_2stream!(ncol, nlay, ngpt, top_at_1,
-                                 tau, ssa, g,
-                                 lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src,
-                                 flux_up, flux_dn)
-    FT = eltype(tau)
-    lev_source = Array{FT}(undef, ncol,nlay+1)
-    source_sfc = Array{FT}(undef, ncol)
-    source_dn = Array{FT}(undef, ncol, nlay)
-    source_up = Array{FT}(undef, ncol, nlay)
-    sfc_albedo = Array{FT}(undef, ncol)
-    Rdif, Tdif, gamma1, gamma2 = ntuple(i->Array{FT}(undef, ncol, nlay),4)
-    for igpt in 1:ngpt
-      #
-      # RRTMGP provides source functions at each level using the spectral mapping
-      #   of each adjacent layer. Combine these for two-stream calculations
-      #
-      lw_combine_sources!(ncol, nlay, top_at_1,
-                          lev_source_inc[:,:,igpt], lev_source_dec[:,:,igpt],
-                          lev_source)
-      #
-      # Cell properties: reflection, transmission for diffuse radiation
-      #   Coupling coefficients needed for source function
-      #
-      lw_two_stream!(ncol, nlay,
-                     tau[:,:,igpt], ssa[:,:,igpt], g[:,:,igpt],
-                     gamma1, gamma2, Rdif, Tdif)
-      #
-      # Source function for diffuse radiation
-      #
-      lw_source_2str!(ncol, nlay, top_at_1,
-                      sfc_emis[:,igpt], sfc_src[:,igpt],
-                      lay_source[:,:,igpt], lev_source,
-                      gamma1, gamma2, Rdif, Tdif, tau[:,:,igpt],
-                      source_dn, source_up, source_sfc)
-      #
-      # Transport
-      #
-      sfc_albedo[1:ncol] = FT(1) .- sfc_emis[:,igpt]
-      adding!(ncol, nlay, top_at_1,
-              sfc_albedo,
-              Rdif, Tdif,
-              source_dn, source_up, source_sfc,
-              @view(flux_up[:,:,igpt]), @view(flux_dn[:,:,igpt]))
-    end
-
+function lw_solver_2stream!(ncol, nlay, ngpt, top_at_1,
+                               tau, ssa, g,
+                               lay_source, lev_source_inc, lev_source_dec, sfc_emis, sfc_src,
+                               flux_up, flux_dn)
+  FT = eltype(tau)
+  lev_source = Array{FT}(undef, ncol,nlay+1)
+  source_sfc = Array{FT}(undef, ncol)
+  source_dn = Array{FT}(undef, ncol, nlay)
+  source_up = Array{FT}(undef, ncol, nlay)
+  sfc_albedo = Array{FT}(undef, ncol)
+  Rdif, Tdif, gamma1, gamma2 = ntuple(i->Array{FT}(undef, ncol, nlay),4)
+  for igpt in 1:ngpt
+    #
+    # RRTMGP provides source functions at each level using the spectral mapping
+    #   of each adjacent layer. Combine these for two-stream calculations
+    #
+    lw_combine_sources!(ncol, nlay, top_at_1,
+                        lev_source_inc[:,:,igpt], lev_source_dec[:,:,igpt],
+                        lev_source)
+    #
+    # Cell properties: reflection, transmission for diffuse radiation
+    #   Coupling coefficients needed for source function
+    #
+    lw_two_stream!(ncol, nlay,
+                   tau[:,:,igpt], ssa[:,:,igpt], g[:,:,igpt],
+                   gamma1, gamma2, Rdif, Tdif)
+    #
+    # Source function for diffuse radiation
+    #
+    lw_source_2str!(ncol, nlay, top_at_1,
+                    sfc_emis[:,igpt], sfc_src[:,igpt],
+                    lay_source[:,:,igpt], lev_source,
+                    gamma1, gamma2, Rdif, Tdif, tau[:,:,igpt],
+                    source_dn, source_up, source_sfc)
+    #
+    # Transport
+    #
+    sfc_albedo[1:ncol] = FT(1) .- sfc_emis[:,igpt]
+    adding!(ncol, nlay, top_at_1,
+            sfc_albedo,
+            Rdif, Tdif,
+            source_dn, source_up, source_sfc,
+            @view(flux_up[:,:,igpt]), @view(flux_dn[:,:,igpt]))
   end
+
+end
+
 # -------------------------------------------------------------------------------------------------
 #
 #   Top-level shortwave kernels
@@ -318,37 +307,35 @@ real(FT), dimension(ncol,nlay+1,ngpt), intent(inout) :: flux_dir     # Direct-be
 integer :: icol, ilev, igpt
 real(FT) :: mu0_inv(ncol)
 """
-
 function sw_solver_noscat!(ncol, nlay, ngpt,
                               top_at_1, tau::Array{FT}, mu0, flux_dir) where FT
 
-    # ------------------------------------
-    mu0_inv[1:ncol] .= FT(1) ./ mu0[1:ncol]
-    # Indexing into arrays for upward and downward propagation depends on the vertical
-    #   orientation of the arrays (whether the domain top is at the first or last index)
-    # We write the loops out explicitly so compilers will have no trouble optimizing them.
+  mu0_inv[1:ncol] .= FT(1) ./ mu0[1:ncol]
+  # Indexing into arrays for upward and downward propagation depends on the vertical
+  #   orientation of the arrays (whether the domain top is at the first or last index)
+  # We write the loops out explicitly so compilers will have no trouble optimizing them.
 
-    # Downward propagation
-    if top_at_1
-      # For the flux at this level, what was the previous level, and which layer has the
-      #   radiation just passed through?
-      # layer index = level index - 1
-      # previous level is up (-1)
-      for igpt in 1:ngpt
-        for ilev in 2:nlay+1
-          flux_dir[:,ilev,igpt] .= flux_dir[:,ilev-1,igpt] .* exp(-tau[:,ilev-1,igpt]*mu0_inv[:])
-        end
+  # Downward propagation
+  if top_at_1
+    # For the flux at this level, what was the previous level, and which layer has the
+    #   radiation just passed through?
+    # layer index = level index - 1
+    # previous level is up (-1)
+    for igpt in 1:ngpt
+      for ilev in 2:nlay+1
+        flux_dir[:,ilev,igpt] .= flux_dir[:,ilev-1,igpt] .* exp(-tau[:,ilev-1,igpt]*mu0_inv[:])
       end
-    else
-      # layer index = level index
-      # previous level is up (+1)
-      for igpt in 1:ngpt
-        for ilev in nlay:-1:1
-          flux_dir[:,ilev,igpt] .= flux_dir[:,ilev+1,igpt] .* exp(-tau[:,ilev,igpt]*mu0_inv[:])
-        end
+    end
+  else
+    # layer index = level index
+    # previous level is up (+1)
+    for igpt in 1:ngpt
+      for ilev in nlay:-1:1
+        flux_dir[:,ilev,igpt] .= flux_dir[:,ilev+1,igpt] .* exp(-tau[:,ilev,igpt]*mu0_inv[:])
       end
     end
   end
+end
 
 # Shortwave two-stream calculation:
 #   compute layer reflectance, transmittance
@@ -383,39 +370,39 @@ function sw_solver_2stream!(ncol, nlay, ngpt, top_at_1,
                                  sfc_alb_dir, sfc_alb_dif,
                                  flux_up, flux_dn, flux_dir) where FT
 
-    Rdif, Tdif, Rdir, Tdir, Tnoscat, source_up, source_dn = ntuple(i->Array{FT}(undef, ncol,nlay), 7)
-    source_srf = Array{FT}(undef, ncol)
+  Rdif, Tdif, Rdir, Tdir, Tnoscat, source_up, source_dn = ntuple(i->Array{FT}(undef, ncol,nlay), 7)
+  source_srf = Array{FT}(undef, ncol)
 
-    for igpt in 1:ngpt
-      #
-      # Cell properties: transmittance and reflectance for direct and diffuse radiation
-      #
+  for igpt in 1:ngpt
+    #
+    # Cell properties: transmittance and reflectance for direct and diffuse radiation
+    #
 
-      Rdif, Tdif, Rdir, Tdir, Tnoscat = sw_two_stream(ncol, nlay, mu0,
-                                                      tau[:,:,igpt],
-                                                      ssa[:,:,igpt],
-                                                      g[:,:,igpt])
-      #
-      # Direct-beam and source for diffuse radiation
-      #
-      sw_source_2str!(ncol, nlay, top_at_1, Rdir, Tdir, Tnoscat, sfc_alb_dir[:,igpt],
-                      source_up, source_dn, source_srf, @view(flux_dir[:,:,igpt]))
+    Rdif, Tdif, Rdir, Tdir, Tnoscat = sw_two_stream(ncol, nlay, mu0,
+                                                    tau[:,:,igpt],
+                                                    ssa[:,:,igpt],
+                                                    g[:,:,igpt])
+    #
+    # Direct-beam and source for diffuse radiation
+    #
+    sw_source_2str!(ncol, nlay, top_at_1, Rdir, Tdir, Tnoscat, sfc_alb_dir[:,igpt],
+                    source_up, source_dn, source_srf, @view(flux_dir[:,:,igpt]))
 
-      #
-      # Transport
-      #
-      adding!(ncol, nlay, top_at_1,
-              sfc_alb_dif[:,igpt], Rdif, Tdif,
-              source_dn, source_up, source_srf,
-              @view(flux_up[:,:,igpt]),
-              @view(flux_dn[:,:,igpt]))
+    #
+    # Transport
+    #
+    adding!(ncol, nlay, top_at_1,
+            sfc_alb_dif[:,igpt], Rdif, Tdif,
+            source_dn, source_up, source_srf,
+            @view(flux_up[:,:,igpt]),
+            @view(flux_dn[:,:,igpt]))
 
-      #
-      # adding computes only diffuse flux; flux_dn is total
-      #
-      flux_dn[:,:,igpt] .= flux_dn[:,:,igpt] .+ flux_dir[:,:,igpt]
-    end
+    #
+    # adding computes only diffuse flux; flux_dn is total
+    #
+    flux_dn[:,:,igpt] .= flux_dn[:,:,igpt] .+ flux_dir[:,:,igpt]
   end
+end
 
 # -------------------------------------------------------------------------------------------------
 #
@@ -450,29 +437,29 @@ real(FT), parameter :: tau_thresh = sqrt(epsilon(tau))
 
 function lw_source_noscat!(ncol, nlay, lay_source, lev_source_up, lev_source_dn, tau, trans,
                               source_dn, source_up)
-    FT = eltype(tau)
-    tau_thresh = sqrt(eps(eltype(tau)))
+  FT = eltype(tau)
+  tau_thresh = sqrt(eps(eltype(tau)))
 #    tau_thresh = abs(eps(eltype(tau)))
-    for ilay in 1:nlay
-      for icol in 1:ncol
-      #
-      # Weighting factor. Use 2nd order series expansion when rounding error (~tau^2)
-      #   is of order epsilon (smallest difference from 1. in working precision)
-      #   Thanks to Peter Blossey
-      #
-      fact = fmerge((FT(1) - trans[icol,ilay])/tau[icol,ilay] - trans[icol,ilay],
-                    tau[icol, ilay] * ( FT(0.5) - FT(1)/FT(3)*tau[icol, ilay]   ),
-                    tau[icol, ilay] > tau_thresh)
-      #
-      # Equation below is developed in Clough et al., 1992, doi:10.1029/92JD01419, Eq 13
-      #
-      source_dn[icol,ilay] = (FT(1) - trans[icol,ilay]) * lev_source_dn[icol,ilay] +
-                              FT(2) * fact * (lay_source[icol,ilay] - lev_source_dn[icol,ilay])
-      source_up[icol,ilay] = (FT(1) - trans[icol,ilay]) * lev_source_up[icol,ilay] +
-                              FT(2) * fact * (lay_source[icol,ilay] - lev_source_up[icol,ilay])
-      end
+  for ilay in 1:nlay
+    for icol in 1:ncol
+    #
+    # Weighting factor. Use 2nd order series expansion when rounding error (~tau^2)
+    #   is of order epsilon (smallest difference from 1. in working precision)
+    #   Thanks to Peter Blossey
+    #
+    fact = fmerge((FT(1) - trans[icol,ilay])/tau[icol,ilay] - trans[icol,ilay],
+                  tau[icol, ilay] * ( FT(0.5) - FT(1)/FT(3)*tau[icol, ilay]   ),
+                  tau[icol, ilay] > tau_thresh)
+    #
+    # Equation below is developed in Clough et al., 1992, doi:10.1029/92JD01419, Eq 13
+    #
+    source_dn[icol,ilay] = (FT(1) - trans[icol,ilay]) * lev_source_dn[icol,ilay] +
+                            FT(2) * fact * (lay_source[icol,ilay] - lev_source_dn[icol,ilay])
+    source_up[icol,ilay] = (FT(1) - trans[icol,ilay]) * lev_source_up[icol,ilay] +
+                            FT(2) * fact * (lay_source[icol,ilay] - lev_source_up[icol,ilay])
     end
   end
+end
 
 # -------------------------------------------------------------------------------------------------
 #
@@ -501,40 +488,40 @@ integer :: ilev
 function lw_transport_noscat!(ncol, nlay, top_at_1,
                                  tau, trans, sfc_albedo, source_dn, source_up, source_sfc,
                                  radn_up, radn_dn)
-    if top_at_1
-      #
-      # Top of domain is index 1
-      #
-      # Downward propagation
-      for ilev in 2:nlay+1
-        radn_dn[:,ilev] .= trans[:,ilev-1].*radn_dn[:,ilev-1] .+ source_dn[:,ilev-1]
-      end
+  if top_at_1
+    #
+    # Top of domain is index 1
+    #
+    # Downward propagation
+    for ilev in 2:nlay+1
+      radn_dn[:,ilev] .= trans[:,ilev-1].*radn_dn[:,ilev-1] .+ source_dn[:,ilev-1]
+    end
 
-      # Surface reflection and emission
-      radn_up[:,nlay+1] .= radn_dn[:,nlay+1].*sfc_albedo[:] .+ source_sfc[:]
+    # Surface reflection and emission
+    radn_up[:,nlay+1] .= radn_dn[:,nlay+1].*sfc_albedo[:] .+ source_sfc[:]
 
-      # Upward propagation
-      for ilev in nlay:-1:1
-        radn_up[:,ilev] .= trans[:,ilev  ].*radn_up[:,ilev+1] .+ source_up[:,ilev]
-      end
-    else
-      #
-      # Top of domain is index nlay+1
-      #
-      # Downward propagation
-      for ilev in nlay:-1:1
-        radn_dn[:,ilev] .= trans[:,ilev  ].*radn_dn[:,ilev+1] .+ source_dn[:,ilev]
-      end
+    # Upward propagation
+    for ilev in nlay:-1:1
+      radn_up[:,ilev] .= trans[:,ilev  ].*radn_up[:,ilev+1] .+ source_up[:,ilev]
+    end
+  else
+    #
+    # Top of domain is index nlay+1
+    #
+    # Downward propagation
+    for ilev in nlay:-1:1
+      radn_dn[:,ilev] .= trans[:,ilev  ].*radn_dn[:,ilev+1] .+ source_dn[:,ilev]
+    end
 
-      # Surface reflection and emission
-      radn_up[:,     1] .= radn_dn[:,     1].*sfc_albedo[:] .+ source_sfc[:]
+    # Surface reflection and emission
+    radn_up[:,     1] .= radn_dn[:,     1].*sfc_albedo[:] .+ source_sfc[:]
 
-      # Upward propagation
-      for ilev in 2:nlay+1
-        radn_up[:,ilev] .= trans[:,ilev-1] .* radn_up[:,ilev-1] .+  source_up[:,ilev-1]
-      end
+    # Upward propagation
+    for ilev in 2:nlay+1
+      radn_up[:,ilev] .= trans[:,ilev-1] .* radn_up[:,ilev-1] .+  source_up[:,ilev-1]
     end
   end
+end
 
 # -------------------------------------------------------------------------------------------------
 #
@@ -569,61 +556,61 @@ real(FT), parameter :: LW_diff_sec = 1.66  # 1./cos(diffusivity angle)
 
 function lw_two_stream!(ncol, nlay, tau, w0, g,
                                 gamma1, gamma2, Rdif, Tdif)
-    FT = eltype(tau)
-    k = Vector{FT}(undef, ncol)
-    RT_term = Vector{FT}(undef, ncol)
-    exp_minusktau = Vector{FT}(undef, ncol)
-    exp_minus2ktau = Vector{FT}(undef, ncol)
-    for j in 1:nlay
-      for i in 1:ncol
-        #
-        # Coefficients differ from SW implementation because the phase function is more isotropic
-        #   Here we follow Fu et al. 1997, doi:10.1175/1520-0469(1997)054<2799:MSPITI>2.0.CO;2
-        #   and use a diffusivity sec of 1.66
-        #
-        gamma1[i,j]= LW_diff_sec(FT) * (FT(1) - FT(0.5) * w0[i,j] * (FT(1) + g[i,j])) # Fu et al. Eq 2.9
-        gamma2[i,j]= LW_diff_sec(FT) *          FT(0.5) * w0[i,j] * (FT(1) - g[i,j])  # Fu et al. Eq 2.10
-      end
-
-      # Written to encourage vectorization of exponential, square root
-      # Eq 18;  k = SQRT(gamma1**2 - gamma2**2), limited below to avoid div by 0.
-      #   k = 0 for isotropic, conservative scattering; this lower limit on k
-      #   gives relative error with respect to conservative solution
-      #   of < 0.1% in Rdif down to tau = 10^-9
-      temp1 = gamma1[1:ncol,j] .- gamma2[1:ncol,j] .*
-              gamma1[1:ncol,j] .+ gamma2[1:ncol,j]
-
-      temp2 = max.(temp1, FT(1.e-12))
-      k[1:ncol] .= sqrt.(temp2)
-      exp_minusktau[1:ncol] .= exp.(-tau[1:ncol,j].*k[1:ncol])
-
+  FT = eltype(tau)
+  k = Vector{FT}(undef, ncol)
+  RT_term = Vector{FT}(undef, ncol)
+  exp_minusktau = Vector{FT}(undef, ncol)
+  exp_minus2ktau = Vector{FT}(undef, ncol)
+  for j in 1:nlay
+    for i in 1:ncol
       #
-      # Diffuse reflection and transmission
+      # Coefficients differ from SW implementation because the phase function is more isotropic
+      #   Here we follow Fu et al. 1997, doi:10.1175/1520-0469(1997)054<2799:MSPITI>2.0.CO;2
+      #   and use a diffusivity sec of 1.66
       #
-      for i in 1:ncol
-        exp_minus2ktau[i] = exp_minusktau[i] * exp_minusktau[i]
-
-        # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
-        RT_term[i] = FT(1) / (k[i] * (FT(1) + exp_minus2ktau[i])  +
-                              gamma1[i,j] * (FT(1) - exp_minus2ktau[i]) )
-
-        # Equation 25
-        Rdif[i,j] = RT_term[i] * gamma2[i,j] * (FT(1) - exp_minus2ktau[i])
-
-        # Equation 26
-        Tdif[i,j] = RT_term[i] * FT(2) * k[i] * exp_minusktau[i]
-      end
-
+      gamma1[i,j]= LW_diff_sec(FT) * (FT(1) - FT(0.5) * w0[i,j] * (FT(1) + g[i,j])) # Fu et al. Eq 2.9
+      gamma2[i,j]= LW_diff_sec(FT) *          FT(0.5) * w0[i,j] * (FT(1) - g[i,j])  # Fu et al. Eq 2.10
     end
+
+    # Written to encourage vectorization of exponential, square root
+    # Eq 18;  k = SQRT(gamma1**2 - gamma2**2), limited below to avoid div by 0.
+    #   k = 0 for isotropic, conservative scattering; this lower limit on k
+    #   gives relative error with respect to conservative solution
+    #   of < 0.1% in Rdif down to tau = 10^-9
+    temp1 = gamma1[1:ncol,j] .- gamma2[1:ncol,j] .*
+            gamma1[1:ncol,j] .+ gamma2[1:ncol,j]
+
+    temp2 = max.(temp1, FT(1.e-12))
+    k[1:ncol] .= sqrt.(temp2)
+    exp_minusktau[1:ncol] .= exp.(-tau[1:ncol,j].*k[1:ncol])
+
+    #
+    # Diffuse reflection and transmission
+    #
+    for i in 1:ncol
+      exp_minus2ktau[i] = exp_minusktau[i] * exp_minusktau[i]
+
+      # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
+      RT_term[i] = FT(1) / (k[i] * (FT(1) + exp_minus2ktau[i])  +
+                            gamma1[i,j] * (FT(1) - exp_minus2ktau[i]) )
+
+      # Equation 25
+      Rdif[i,j] = RT_term[i] * gamma2[i,j] * (FT(1) - exp_minus2ktau[i])
+
+      # Equation 26
+      Tdif[i,j] = RT_term[i] * FT(2) * k[i] * exp_minusktau[i]
+    end
+
   end
-  # -------------------------------------------------------------------------------------------------
-  #
-  # Source function combination
-  # RRTMGP provides two source functions at each level
-  #   using the spectral mapping from each of the adjascent layers.
-  #   Need to combine these for use in two-stream calculation.
-  #
-  # -------------------------------------------------------------------------------------------------
+end
+# -------------------------------------------------------------------------------------------------
+#
+# Source function combination
+# RRTMGP provides two source functions at each level
+#   using the spectral mapping from each of the adjascent layers.
+#   Need to combine these for use in two-stream calculation.
+#
+# -------------------------------------------------------------------------------------------------
 
 """
     lw_combine_sources!(...)
@@ -638,29 +625,29 @@ function lw_two_stream!(ncol, nlay, tau, w0, g,
 """
 function lw_combine_sources!(ncol, nlay, top_at_1,
                                 lev_src_inc, lev_src_dec, lev_source)
-    ilay = 1
-    for icol in 1:ncol
-      lev_source[icol, ilay] =        lev_src_dec[icol, ilay]
-    end
-    for ilay in 2:nlay
-      for icol in 1:ncol
-        lev_source[icol, ilay] = sqrt(lev_src_dec[icol, ilay] *
-                                      lev_src_inc[icol, ilay-1])
-      end
-    end
-    ilay = nlay+1
-    for icol in 1:ncol
-      lev_source[icol, ilay] =        lev_src_inc[icol, ilay-1]
-    end
-
+  ilay = 1
+  for icol in 1:ncol
+    lev_source[icol, ilay] =        lev_src_dec[icol, ilay]
   end
-  # ---------------------------------------------------------------
-  #
-  # Compute LW source function for upward and downward emission at levels using linear-in-tau assumption
-  #   This version straight from ECRAD
-  #   Source is provided as W/m2-str; factor of π converts to flux units
-  #
-  # ---------------------------------------------------------------
+  for ilay in 2:nlay
+    for icol in 1:ncol
+      lev_source[icol, ilay] = sqrt(lev_src_dec[icol, ilay] *
+                                    lev_src_inc[icol, ilay-1])
+    end
+  end
+  ilay = nlay+1
+  for icol in 1:ncol
+    lev_source[icol, ilay] =        lev_src_inc[icol, ilay-1]
+  end
+
+end
+# ---------------------------------------------------------------
+#
+# Compute LW source function for upward and downward emission at levels using linear-in-tau assumption
+#   This version straight from ECRAD
+#   Source is provided as W/m2-str; factor of π converts to flux units
+#
+# ---------------------------------------------------------------
 
 """
     lw_source_2str!(...)
@@ -687,51 +674,51 @@ function lw_source_2str!(ncol, nlay, top_at_1,
                             lay_source, lev_source,
                             gamma1, gamma2, rdif, tdif, tau, source_dn, source_up, source_sfc)
 
-    FT = eltype(tau)
-    for ilay in 1:nlay
-      if top_at_1
-        lev_source_top = lev_source[:,ilay]
-        lev_source_bot = lev_source[:,ilay+1]
-      else
-        lev_source_top = lev_source[:,ilay+1]
-        lev_source_bot = lev_source[:,ilay]
-      end
-      for icol in 1:ncol
-        if tau[icol,ilay] > FT(1.0e-8)
-          #
-          # Toon et al. (JGR 1989) Eqs 26-27
-          #
-          Z = (lev_source_bot[icol]-lev_source_top[icol]) / (tau[icol,ilay]*(gamma1[icol,ilay]+gamma2[icol,ilay]))
-          Zup_top        =  Z + lev_source_top[icol]
-          Zup_bottom     =  Z + lev_source_bot[icol]
-          Zdn_top        = -Z + lev_source_top[icol]
-          Zdn_bottom     = -Z + lev_source_bot[icol]
-          source_up[icol,ilay] = π * (Zup_top    - rdif[icol,ilay] * Zdn_top    - tdif[icol,ilay] * Zup_bottom)
-          source_dn[icol,ilay] = π * (Zdn_bottom - rdif[icol,ilay] * Zup_bottom - tdif[icol,ilay] * Zdn_top)
-        else
-          source_up[icol,ilay] = FT(0)
-          source_dn[icol,ilay] = FT(0)
-        end
-      end
+  FT = eltype(tau)
+  for ilay in 1:nlay
+    if top_at_1
+      lev_source_top = lev_source[:,ilay]
+      lev_source_bot = lev_source[:,ilay+1]
+    else
+      lev_source_top = lev_source[:,ilay+1]
+      lev_source_bot = lev_source[:,ilay]
     end
     for icol in 1:ncol
-      source_sfc[icol] = π * sfc_emis[icol] * sfc_src[icol]
+      if tau[icol,ilay] > FT(1.0e-8)
+        #
+        # Toon et al. (JGR 1989) Eqs 26-27
+        #
+        Z = (lev_source_bot[icol]-lev_source_top[icol]) / (tau[icol,ilay]*(gamma1[icol,ilay]+gamma2[icol,ilay]))
+        Zup_top        =  Z + lev_source_top[icol]
+        Zup_bottom     =  Z + lev_source_bot[icol]
+        Zdn_top        = -Z + lev_source_top[icol]
+        Zdn_bottom     = -Z + lev_source_bot[icol]
+        source_up[icol,ilay] = π * (Zup_top    - rdif[icol,ilay] * Zdn_top    - tdif[icol,ilay] * Zup_bottom)
+        source_dn[icol,ilay] = π * (Zdn_bottom - rdif[icol,ilay] * Zup_bottom - tdif[icol,ilay] * Zdn_top)
+      else
+        source_up[icol,ilay] = FT(0)
+        source_dn[icol,ilay] = FT(0)
+      end
     end
   end
+  for icol in 1:ncol
+    source_sfc[icol] = π * sfc_emis[icol] * sfc_src[icol]
+  end
+end
 
-  # -------------------------------------------------------------------------------------------------
-  #
-  #   Lower-level shortwave kernels
-  #
-  # -------------------------------------------------------------------------------------------------
-  #
-  # Two-stream solutions to direct and diffuse reflectance and transmittance for a layer
-  #    with optical depth tau, single scattering albedo w0, and asymmetery parameter g.
-  #
-  # Equations are developed in Meador and Weaver, 1980,
-  #    doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
-  #
-  # -------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------
+#
+#   Lower-level shortwave kernels
+#
+# -------------------------------------------------------------------------------------------------
+#
+# Two-stream solutions to direct and diffuse reflectance and transmittance for a layer
+#    with optical depth tau, single scattering albedo w0, and asymmetery parameter g.
+#
+# Equations are developed in Meador and Weaver, 1980,
+#    doi:10.1175/1520-0469(1980)037<0630:TSATRT>2.0.CO;2
+#
+# -------------------------------------------------------------------------------------------------
 
 """
     sw_two_stream!(...)
@@ -756,104 +743,104 @@ function lw_source_2str!(ncol, nlay, top_at_1,
     # ---------------------------------
 """
 function sw_two_stream(ncol, nlay, mu0, tau, w0, g)
-    FT = eltype(tau)
-    mu0_inv = 1 ./ mu0
-    exp_minusktau = Array{FT}(undef, ncol)
-    exp_minus2ktau = Array{FT}(undef, ncol)
-    RT_term = Array{FT}(undef, ncol)
+  FT = eltype(tau)
+  mu0_inv = 1 ./ mu0
+  exp_minusktau = Array{FT}(undef, ncol)
+  exp_minus2ktau = Array{FT}(undef, ncol)
+  RT_term = Array{FT}(undef, ncol)
 
-    Rdif, Tdif, Rdir, Tdir, Tnoscat = ntuple(i-> Array{FT}(undef, ncol,nlay), 5)
+  Rdif, Tdif, Rdir, Tdir, Tnoscat = ntuple(i-> Array{FT}(undef, ncol,nlay), 5)
 
-    gamma1, gamma2, gamma3, gamma4, alpha1, alpha2, k = ntuple(i->Array{FT}(undef, ncol), 7)
+  gamma1, gamma2, gamma3, gamma4, alpha1, alpha2, k = ntuple(i->Array{FT}(undef, ncol), 7)
 
-    for j in 1:nlay
-      for i in 1:ncol
-        # Zdunkowski Practical Improved Flux Method "PIFM"
-        #  (Zdunkowski et al., 1980;  Contributions to Atmospheric Physics 53, 147-66)
-        #
-        gamma1[i]= (FT(8) - w0[i,j] * (FT(5) + FT(3) * g[i,j])) * FT(.25)
-        gamma2[i]=  FT(3) *(w0[i,j] * (FT(1) -         g[i,j])) * FT(.25)
-        gamma3[i]= (FT(2) - FT(3) * mu0[i] *           g[i,j] ) * FT(.25)
-        gamma4[i]=  FT(1) - gamma3[i]
-
-        alpha1[i] = gamma1[i] * gamma4[i] + gamma2[i] * gamma3[i]           # Eq. 16
-        alpha2[i] = gamma1[i] * gamma3[i] + gamma2[i] * gamma4[i]           # Eq. 17
-      end
-
-      # Written to encourage vectorization of exponential, square root
-      # Eq 18;  k = SQRT(gamma1**2 - gamma2**2), limited below to avoid div by 0.
-      #   k = 0 for isotropic, conservative scattering; this lower limit on k
-      #   gives relative error with respect to conservative solution
-      #   of < 0.1% in Rdif down to tau = 10^-9
-      temp = (gamma1[1:ncol] .- gamma2[1:ncol]) .*
-             (gamma1[1:ncol] .+ gamma2[1:ncol])
-      k[1:ncol] .= sqrt.(max( temp..., FT(1.e-12)))
-      exp_minusktau[1:ncol] .= exp.(-tau[1:ncol,j] .* k[1:ncol])
-
+  for j in 1:nlay
+    for i in 1:ncol
+      # Zdunkowski Practical Improved Flux Method "PIFM"
+      #  (Zdunkowski et al., 1980;  Contributions to Atmospheric Physics 53, 147-66)
       #
-      # Diffuse reflection and transmission
-      #
-      for i in 1:ncol
-        exp_minus2ktau[i] = exp_minusktau[i] * exp_minusktau[i]
+      gamma1[i]= (FT(8) - w0[i,j] * (FT(5) + FT(3) * g[i,j])) * FT(.25)
+      gamma2[i]=  FT(3) *(w0[i,j] * (FT(1) -         g[i,j])) * FT(.25)
+      gamma3[i]= (FT(2) - FT(3) * mu0[i] *           g[i,j] ) * FT(.25)
+      gamma4[i]=  FT(1) - gamma3[i]
 
-        # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
-        RT_term[i] = FT(1) / (     k[i] * (FT(1) + exp_minus2ktau[i])  +
-                              gamma1[i] * (FT(1) - exp_minus2ktau[i]) )
-
-        # Equation 25
-        Rdif[i,j] = RT_term[i] * gamma2[i] * (FT(1) - exp_minus2ktau[i])
-
-        # Equation 26
-        Tdif[i,j] = RT_term[i] * FT(2) * k[i] * exp_minusktau[i]
-      end
-
-      #
-      # Transmittance of direct, unscattered beam. Also used below
-      #
-      Tnoscat[1:ncol,j] .= exp.(-tau[1:ncol,j] .* mu0_inv[1:ncol])
-
-      #
-      # Direct reflect and transmission
-      #
-      for i in 1:ncol
-        k_mu     = k[i] * mu0[i]
-        k_gamma3 = k[i] * gamma3[i]
-        k_gamma4 = k[i] * gamma4[i]
-
-        #
-        # Equation 14, multiplying top and bottom by exp(-k*tau)
-        #   and rearranging to avoid div by 0.
-        #
-        RT_term[i] =  w0[i,j] * RT_term[i]/fmerge(FT(1) - k_mu*k_mu,
-                                                  eps(FT),
-                                                  abs(FT(1) - k_mu*k_mu) >= eps(FT))
-
-        Rdir[i,j] = RT_term[i]  *
-            ((FT(1) - k_mu) * (alpha2[i] + k_gamma3)                     -
-             (FT(1) + k_mu) * (alpha2[i] - k_gamma3) * exp_minus2ktau[i] -
-              FT(2) * (k_gamma3 - alpha2[i] * k_mu)  * exp_minusktau[i] * Tnoscat[i,j])
-
-        #
-        # Equation 15, multiplying top and bottom by exp(-k*tau),
-        #   multiplying through by exp(-tau/mu0) to
-        #   prefer underflow to overflow
-        # Omitting direct transmittance
-        #
-        Tdir[i,j] = -RT_term[i] *
-                    ((FT(1) + k_mu) * (alpha1[i] + k_gamma4)                     * Tnoscat[i,j] -
-                     (FT(1) - k_mu) * (alpha1[i] - k_gamma4) * exp_minus2ktau[i] * Tnoscat[i,j] -
-                      FT(2) * (k_gamma4 + alpha1[i] * k_mu)  * exp_minusktau[i])
-
-      end
+      alpha1[i] = gamma1[i] * gamma4[i] + gamma2[i] * gamma3[i]           # Eq. 16
+      alpha2[i] = gamma1[i] * gamma3[i] + gamma2[i] * gamma4[i]           # Eq. 17
     end
-    return Rdif, Tdif, Rdir, Tdir, Tnoscat
+
+    # Written to encourage vectorization of exponential, square root
+    # Eq 18;  k = SQRT(gamma1**2 - gamma2**2), limited below to avoid div by 0.
+    #   k = 0 for isotropic, conservative scattering; this lower limit on k
+    #   gives relative error with respect to conservative solution
+    #   of < 0.1% in Rdif down to tau = 10^-9
+    temp = (gamma1[1:ncol] .- gamma2[1:ncol]) .*
+           (gamma1[1:ncol] .+ gamma2[1:ncol])
+    k[1:ncol] .= sqrt.(max( temp..., FT(1.e-12)))
+    exp_minusktau[1:ncol] .= exp.(-tau[1:ncol,j] .* k[1:ncol])
+
+    #
+    # Diffuse reflection and transmission
+    #
+    for i in 1:ncol
+      exp_minus2ktau[i] = exp_minusktau[i] * exp_minusktau[i]
+
+      # Refactored to avoid rounding errors when k, gamma1 are of very different magnitudes
+      RT_term[i] = FT(1) / (     k[i] * (FT(1) + exp_minus2ktau[i])  +
+                            gamma1[i] * (FT(1) - exp_minus2ktau[i]) )
+
+      # Equation 25
+      Rdif[i,j] = RT_term[i] * gamma2[i] * (FT(1) - exp_minus2ktau[i])
+
+      # Equation 26
+      Tdif[i,j] = RT_term[i] * FT(2) * k[i] * exp_minusktau[i]
+    end
+
+    #
+    # Transmittance of direct, unscattered beam. Also used below
+    #
+    Tnoscat[1:ncol,j] .= exp.(-tau[1:ncol,j] .* mu0_inv[1:ncol])
+
+    #
+    # Direct reflect and transmission
+    #
+    for i in 1:ncol
+      k_mu     = k[i] * mu0[i]
+      k_gamma3 = k[i] * gamma3[i]
+      k_gamma4 = k[i] * gamma4[i]
+
+      #
+      # Equation 14, multiplying top and bottom by exp(-k*tau)
+      #   and rearranging to avoid div by 0.
+      #
+      RT_term[i] =  w0[i,j] * RT_term[i]/fmerge(FT(1) - k_mu*k_mu,
+                                                eps(FT),
+                                                abs(FT(1) - k_mu*k_mu) >= eps(FT))
+
+      Rdir[i,j] = RT_term[i]  *
+          ((FT(1) - k_mu) * (alpha2[i] + k_gamma3)                     -
+           (FT(1) + k_mu) * (alpha2[i] - k_gamma3) * exp_minus2ktau[i] -
+            FT(2) * (k_gamma3 - alpha2[i] * k_mu)  * exp_minusktau[i] * Tnoscat[i,j])
+
+      #
+      # Equation 15, multiplying top and bottom by exp(-k*tau),
+      #   multiplying through by exp(-tau/mu0) to
+      #   prefer underflow to overflow
+      # Omitting direct transmittance
+      #
+      Tdir[i,j] = -RT_term[i] *
+                  ((FT(1) + k_mu) * (alpha1[i] + k_gamma4)                     * Tnoscat[i,j] -
+                   (FT(1) - k_mu) * (alpha1[i] - k_gamma4) * exp_minus2ktau[i] * Tnoscat[i,j] -
+                    FT(2) * (k_gamma4 + alpha1[i] * k_mu)  * exp_minusktau[i])
+
+    end
   end
-  # ---------------------------------------------------------------
-  #
-  # Direct beam source for diffuse radiation in layers and at surface;
-  #   report direct beam as a byproduct
-  #
-  # -------------------------------------------------------------------------------------------------
+  return Rdif, Tdif, Rdir, Tdir, Tnoscat
+end
+# ---------------------------------------------------------------
+#
+# Direct beam source for diffuse radiation in layers and at surface;
+#   report direct beam as a byproduct
+#
+# -------------------------------------------------------------------------------------------------
 """
     sw_source_2str!(...)
 
@@ -872,24 +859,25 @@ function sw_two_stream(ncol, nlay, mu0, tau, w0, g)
 function sw_source_2str!(ncol, nlay, top_at_1, Rdir, Tdir, Tnoscat, sfc_albedo,
                             source_up, source_dn, source_sfc, flux_dn_dir)
 
-    if top_at_1
-      for ilev in 1:nlay
-        source_up[:,ilev]     .=    Rdir[:,ilev] .* flux_dn_dir[:,ilev]
-        source_dn[:,ilev]     .=    Tdir[:,ilev] .* flux_dn_dir[:,ilev]
-        flux_dn_dir[:,ilev+1] .= Tnoscat[:,ilev] .* flux_dn_dir[:,ilev]
-      end
-      source_sfc[:] .= flux_dn_dir[:,nlay+1] .* sfc_albedo[:]
-    else
-      # layer index = level index
-      # previous level is up (+1)
-      for ilev in nlay:-1:1
-        source_up[:,ilev]   .=    Rdir[:,ilev] .* flux_dn_dir[:,ilev+1]
-        source_dn[:,ilev]   .=    Tdir[:,ilev] .* flux_dn_dir[:,ilev+1]
-        flux_dn_dir[:,ilev] .= Tnoscat[:,ilev] .* flux_dn_dir[:,ilev+1]
-      end
-      source_sfc[:] .= flux_dn_dir[:,     1] .* sfc_albedo[:]
+  if top_at_1
+    for ilev in 1:nlay
+      source_up[:,ilev]     .=    Rdir[:,ilev] .* flux_dn_dir[:,ilev]
+      source_dn[:,ilev]     .=    Tdir[:,ilev] .* flux_dn_dir[:,ilev]
+      flux_dn_dir[:,ilev+1] .= Tnoscat[:,ilev] .* flux_dn_dir[:,ilev]
     end
+    source_sfc[:] .= flux_dn_dir[:,nlay+1] .* sfc_albedo[:]
+  else
+    # layer index = level index
+    # previous level is up (+1)
+    for ilev in nlay:-1:1
+      source_up[:,ilev]   .=    Rdir[:,ilev] .* flux_dn_dir[:,ilev+1]
+      source_dn[:,ilev]   .=    Tdir[:,ilev] .* flux_dn_dir[:,ilev+1]
+      flux_dn_dir[:,ilev] .= Tnoscat[:,ilev] .* flux_dn_dir[:,ilev+1]
+    end
+    source_sfc[:] .= flux_dn_dir[:,     1] .* sfc_albedo[:]
+  end
 end
+
 # ---------------------------------------------------------------
 #
 # Transport of diffuse radiation through a vertically layered atmosphere.
@@ -920,7 +908,6 @@ end
   real(FT), dimension(ncol,nlay  )  :: denom      # beta in SH08
   # ------------------
 """
-
 function adding!(ncol, nlay, top_at_1,
                   albedo_sfc,
                   rdif, tdif,

--- a/src/rte/mo_rte_sw.jl
+++ b/src/rte/mo_rte_sw.jl
@@ -85,9 +85,9 @@ function rte_sw!(atmos::ty_optical_props_arry,
   @assert !any_vals_outside(sfc_alb_dif, FT(0), FT(1))
   @assert !(atmos isa ty_optical_props_nstr) # not yet implemented...
 
-  gpt_flux_up  = Array{FT}(undef,ncol, nlay+1, ngpt)
-  gpt_flux_dn  = Array{FT}(undef,ncol, nlay+1, ngpt)
-  gpt_flux_dir = Array{FT}(undef,ncol, nlay+1, ngpt)
+  gpt_flux_up  = zeros(FT, ncol, nlay+1, ngpt)
+  gpt_flux_dn  = zeros(FT, ncol, nlay+1, ngpt)
+  gpt_flux_dir = zeros(FT, ncol, nlay+1, ngpt)
 
   # Lower boundary condition -- expand surface albedos by band to gpoints
   #   and switch dimension ordering
@@ -144,7 +144,7 @@ function expand_and_transpose(ops::ty_optical_props,arr_in::Array{FT}) where FT
   ncol  = size(arr_in,2)
   nband = get_nband(ops)
   ngpt  = get_ngpt(ops)
-  arr_out = Array{FT}(undef,ncol, ngpt)
+  arr_out = zeros(FT, ncol, ngpt)
   limits = get_band_lims_gpoint(ops)
   for iband = 1:nband
     for icol = 1:ncol

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -298,9 +298,14 @@ function run_driver(datafolder, optical_props_constructor, nblocks_iterations=no
   close(ds_k_dist)
 end
 
-@testset "Shortwave driver" begin
+@testset "Shortwave driver ty_optical_props_1scl" begin
   datafolder = JRRTMGP.data_folder_rrtmgp()
 
   run_driver(datafolder, ty_optical_props_1scl)
+end
+
+@testset "Shortwave driver ty_optical_props_2str" begin
+  datafolder = JRRTMGP.data_folder_rrtmgp()
+
   run_driver(datafolder, ty_optical_props_2str)
 end

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -148,8 +148,8 @@ function run_driver(datafolder, optical_props_constructor, nblocks_iterations=no
   nbnd = get_nband(k_dist.optical_props)
   ngpt = get_ngpt(k_dist.optical_props)
 
-  toa_flux = Array{FT}(undef, block_size, get_ngpt(k_dist.optical_props))
-  def_tsi = Array{FT}(undef, block_size)
+  toa_flux = zeros(FT, block_size, get_ngpt(k_dist.optical_props))
+  def_tsi = zeros(FT, block_size)
   usecol = Array{Bool}(undef, block_size, nblocks)
   #
   # RRTMGP won't run with pressure less than its minimum. The top level in the RFMIP file
@@ -179,8 +179,8 @@ function run_driver(datafolder, optical_props_constructor, nblocks_iterations=no
   flux_up = zeros(FT, block_size, nlay+1, nblocks)
   flux_dn = zeros(FT, block_size, nlay+1, nblocks)
 
-  mu0 = Array{FT}(undef, block_size)
-  sfc_alb_spec = Array{FT}(undef, nbnd,block_size)
+  mu0 = zeros(FT, block_size)
+  sfc_alb_spec = zeros(FT, nbnd,block_size)
   optical_props = optical_props_constructor(FT, Int)
   copy_and_alloc!(optical_props, block_size, nlay, k_dist.optical_props)
 

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -283,8 +283,8 @@ function run_driver(datafolder, optical_props_constructor, nblocks_iterations=no
     @test diff_up_ulps < sqrt(1/(1e6eps(FT)))
     @test diff_dn_ulps < sqrt(1/(1e6eps(FT)))
   else
-    @test diff_up_ulps < sqrt(1/(1e6eps(FT)))
-    @test diff_dn_ulps < sqrt(1/(1e6eps(FT)))
+    @test diff_up_ulps < sqrt(1/(eps(FT))) # 1.6776966e7
+    @test diff_dn_ulps < sqrt(1/(eps(FT))) # 1.6777158e7
   end
 
   # flxdn_file = "rsd_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f" * string(forcing_index) * "_gn.nc"
@@ -301,6 +301,6 @@ end
 @testset "Shortwave driver" begin
   datafolder = JRRTMGP.data_folder_rrtmgp()
 
-  # run_driver(datafolder, ty_optical_props_1scl)
+  run_driver(datafolder, ty_optical_props_1scl)
   run_driver(datafolder, ty_optical_props_2str)
 end

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -32,7 +32,7 @@ using JRRTMGP.mo_rfmip_io
 #   All arguments are optional but need to be specified in order.
 #
 
-function run_driver(datafolder, nblocks_iterations=nothing)
+function run_driver(datafolder, optical_props_constructor, nblocks_iterations=nothing)
   #
   # RTE shortwave driver
   #
@@ -181,7 +181,7 @@ function run_driver(datafolder, nblocks_iterations=nothing)
 
   mu0 = Array{FT}(undef, block_size)
   sfc_alb_spec = Array{FT}(undef, nbnd,block_size)
-  optical_props = ty_optical_props_2str(FT, Int)
+  optical_props = optical_props_constructor(FT, Int)
   copy_and_alloc!(optical_props, block_size, nlay, k_dist.optical_props)
 
   #
@@ -279,8 +279,13 @@ function run_driver(datafolder, nblocks_iterations=nothing)
   # @show diff_up, diff_up_ulps, maximum(abs.(rsu_for))
   # @show diff_dn, diff_dn_ulps, maximum(abs.(rsd_for))
 
-  @test diff_up_ulps < sqrt(1/(1e6eps(FT)))
-  @test diff_dn_ulps < sqrt(1/(1e6eps(FT)))
+  if optical_props_constructor isa ty_optical_props_2str
+    @test diff_up_ulps < sqrt(1/(1e6eps(FT)))
+    @test diff_dn_ulps < sqrt(1/(1e6eps(FT)))
+  else
+    @test diff_up_ulps < sqrt(1/(1e6eps(FT)))
+    @test diff_dn_ulps < sqrt(1/(1e6eps(FT)))
+  end
 
   # flxdn_file = "rsd_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f" * string(forcing_index) * "_gn.nc"
   # flxup_file = "rsu_Efx_RTE-RRTMGP-181204_rad-irf_r1i1p1f" * string(forcing_index) * "_gn.nc"
@@ -296,5 +301,6 @@ end
 @testset "Shortwave driver" begin
   datafolder = JRRTMGP.data_folder_rrtmgp()
 
-  run_driver(datafolder)
+  # run_driver(datafolder, ty_optical_props_1scl)
+  run_driver(datafolder, ty_optical_props_2str)
 end

--- a/test/rfmip_clear_sky_sw.jl
+++ b/test/rfmip_clear_sky_sw.jl
@@ -298,14 +298,9 @@ function run_driver(datafolder, optical_props_constructor, nblocks_iterations=no
   close(ds_k_dist)
 end
 
-@testset "Shortwave driver ty_optical_props_1scl" begin
+@testset "Shortwave driver" begin
   datafolder = JRRTMGP.data_folder_rrtmgp()
 
   run_driver(datafolder, ty_optical_props_1scl)
-end
-
-@testset "Shortwave driver ty_optical_props_2str" begin
-  datafolder = JRRTMGP.data_folder_rrtmgp()
-
   run_driver(datafolder, ty_optical_props_2str)
 end


### PR DESCRIPTION
Adds a shortwave rfmip clear sky test with `ty_optical_props_1scl` instead of `ty_optical_props_2str`