### PR TITLE
Move remaining fortran code to separate folder

### DIFF
--- a/RemainingFortranCode/mo_compute_bc.f90
+++ b/RemainingFortranCode/mo_compute_bc.f90
@@ -1,24 +1,24 @@
 module mo_compute_bc
-  # This code is part of RRTM for GCM Applications - Parallel (RRTMGP)
-  #
-  # Contacts: Robert Pincus and Eli Mlawer
-  # email:  rrtmgp@aer.com
-  #
-  # Copyright 2018,  Atmospheric and Environmental Research and
-  # Regents of the University of Colorado.  All right reserved.
-  #
-  # Use and duplication is permitted under the terms of the
-  #    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
-  # -------------------------------------------------------------------------------------------------
-  # This modules lets users determine upper boundary condition by
-  #   computing the spectrally-resolved fluxes at the bottom of an isothermal layer
-  #   extending from the lowest supplied pressure to the minimum pressure allowed by
-  #   RRTMGP.
-  # This is only sensible if the user's domain extends nearly to the top of the atmosphere.
-  # Adding this thin extra layer makes heating rates in the top-most layer more reasonable
-  #   especially in the longwave
-  # The boundary condition is on diffuse flux in the LW and direct flux in the SW
-  # -------------------------------------------------------------------------------------------------
+  ! This code is part of RRTM for GCM Applications - Parallel (RRTMGP)
+  !
+  ! Contacts: Robert Pincus and Eli Mlawer
+  ! email:  rrtmgp@aer.com
+  !
+  ! Copyright 2018,  Atmospheric and Environmental Research and
+  ! Regents of the University of Colorado.  All right reserved.
+  !
+  ! Use and duplication is permitted under the terms of the
+  !    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+  ! -------------------------------------------------------------------------------------------------
+  ! This modules lets users determine upper boundary condition by
+  !   computing the spectrally-resolved fluxes at the bottom of an isothermal layer
+  !   extending from the lowest supplied pressure to the minimum pressure allowed by
+  !   RRTMGP.
+  ! This is only sensible if the user's domain extends nearly to the top of the atmosphere.
+  ! Adding this thin extra layer makes heating rates in the top-most layer more reasonable
+  !   especially in the longwave
+  ! The boundary condition is on diffuse flux in the LW and direct flux in the SW
+  ! -------------------------------------------------------------------------------------------------
   use mo_rte_kind,           only: FT, wl
   use mo_source_functions,   only: ty_source_func_lw
   use mo_gas_concentrations, only: ty_gas_concs
@@ -32,37 +32,37 @@ module mo_compute_bc
   private
   public :: compute_bc
 
-  #
-  # Extend ty_fluxes to report spectrally-resolved downwelling flux at a single layer
-  #
+  !
+  ! Extend ty_fluxes to report spectrally-resolved downwelling flux at a single layer
+  !
   type, extends(ty_fluxes) :: ty_fluxes_1lev
-    real(FT), dimension(:,:), pointer :: gpt_flux_dn => NULL()    # (ncol, nlev, nband)
+    real(FT), dimension(:,:), pointer :: gpt_flux_dn => NULL()    ! (ncol, nlev, nband)
   contains
     procedure :: reduce => reduce_1lev
     procedure :: are_desired => are_desired_1lev
   end type ty_fluxes_1lev
 contains
-  #--------------------------------------------------------------------------------------------------------------------
-  #
-  # The arguments to this routine follow those to the gas_optics routines
-  #
+  !--------------------------------------------------------------------------------------------------------------------
+  !
+  ! The arguments to this routine follow those to the gas_optics routines
+  !
   function compute_bc(k_dist,                      &
                       play, plev, tlay, gas_concs, &
                       flux_bc, mu0) result(error_msg)
     class(ty_gas_optics),     intent(in   ) :: k_dist
-    real(FT), dimension(:,:), intent(in   ) :: play, &    # layer pressures [Pa, mb]; (ncol,nlay)
-                                               plev, &    # level pressures [Pa, mb]; (ncol,nlay+1)
-                                               tlay       # layer temperatures [K]; (ncol,nlay)
-    type(ty_gas_concs),       intent(in   ) :: gas_concs  # Gas volume mixing ratios
+    real(FT), dimension(:,:), intent(in   ) :: play, &    ! layer pressures [Pa, mb]; (ncol,nlay)
+                                               plev, &    ! level pressures [Pa, mb]; (ncol,nlay+1)
+                                               tlay       ! layer temperatures [K]; (ncol,nlay)
+    type(ty_gas_concs),       intent(in   ) :: gas_concs  ! Gas volume mixing ratios
     real(FT), dimension(:,:), target, &
-                              intent(  out) :: flux_bc    # Boundary condition to be applied (ncol,ngpt)
+                              intent(  out) :: flux_bc    ! Boundary condition to be applied (ncol,ngpt)
     real(FT), dimension(:), optional, &
-                              intent(in   ) :: mu0        # Must be provided for solar problems
+                              intent(in   ) :: mu0        ! Must be provided for solar problems
     character(len=128)                      :: error_msg
-    # ----------------------------------------------------------
-    #
-    # Local variables
-    #
+    ! ----------------------------------------------------------
+    !
+    ! Local variables
+    !
     logical :: top_at_1
     integer :: ncol, nlay, ngpt
 
@@ -74,17 +74,17 @@ contains
     real(FT), dimension(size(play,1), 1) :: play_1lay, tlay_1lay
     real(FT), dimension(size(play,1), 2) :: plev_1lay, tlev_1lay
     real(FT), dimension(k_dist%get_nband(),size(play,1)) &
-                                          :: lower_bc # emissivity or surface albedo
-    type(ty_gas_concs)                    :: gas_concs_1lay  # Gas volume mixing ratios
+                                          :: lower_bc ! emissivity or surface albedo
+    type(ty_gas_concs)                    :: gas_concs_1lay  ! Gas volume mixing ratios
     class(ty_optical_props_arry), &
                               allocatable :: optical_props_1lay
     type(ty_fluxes_1lev)                  :: fluxes_1lev
     type(ty_source_func_lw)               :: lw_sources_1lay
     real(FT), dimension(size(play,1),k_dist%get_ngpt()) :: solar_src
-    # ----------------------------------------------------------
-    #
-    # Problem extent
-    #
+    ! ----------------------------------------------------------
+    !
+    ! Problem extent
+    !
     ncol  = size(play, dim=1)
     nlay  = size(play, dim=2)
     ngpt  = k_dist%get_ngpt()
@@ -103,9 +103,9 @@ contains
       end if
     end if
 
-    #
-    # Vertical ordering?
-    #
+    !
+    ! Vertical ordering?
+    !
     top_at_1 = play(1, 1) < play(1, nlay)
     top_lay = merge(1, nlay, top_at_1)
     if(any(plev(:,top_lay) <= &
@@ -113,23 +113,23 @@ contains
       error_msg = "compute_bc: pressures are too close to (or less than) min in gas optics "
       return
     end if
-    #
-    # Make a single-layer isothermal atmosphere
-    #
+    !
+    ! Make a single-layer isothermal atmosphere
+    !
     tlay_1lay(1:ncol,1) = tlay(1:ncol, top_lay)
     tlev_1lay(1:ncol,1) = tlay(1:ncol, top_lay)
     tlev_1lay(1:ncol,2) = tlay(1:ncol, top_lay)
     plev_1lay(1:ncol,1) = k_dist%get_press_min()
     plev_1lay(1:ncol,2) = plev(1:ncol, top_lay+1)
-    #
-    # Maybe there are better ways to interpolate pressure but the single layer
-    #   should be thin enough that interpolation doesn't have much impact
-    #
+    !
+    ! Maybe there are better ways to interpolate pressure but the single layer
+    !   should be thin enough that interpolation doesn't have much impact
+    !
     play_1lay(1:ncol,1) = 0.5 * (plev_1lay(1:ncol,1) + plev_1lay(1:ncol,2))
 
-    #
-    # Gas concentrations in the single layer are the same as in the top layer
-    #
+    !
+    ! Gas concentrations in the single layer are the same as in the top layer
+    !
     ngases = gas_concs%get_num_gases()
     allocate(gas_names(ngases))
     gas_names = gas_concs%get_gas_names()
@@ -140,13 +140,13 @@ contains
       if(error_msg /= "") return
     end do
 
-    lower_bc(:,:) = 1._wp # Value doesn't affect downward flux
+    lower_bc(:,:) = 1._wp ! Value doesn't affect downward flux
     fluxes_1lev%gpt_flux_dn => flux_bc
-    # ---------------------------------------------------
+    ! ---------------------------------------------------
     if(k_dist%source_is_internal()) then
-      #
-      # Longwave specific variables
-      #
+      !
+      ! Longwave specific variables
+      !
       allocate(ty_optical_props_1scl::optical_props_1lay)
       select type (optical_props_1lay)
         type is (ty_optical_props_1scl)
@@ -155,24 +155,24 @@ contains
       end select
       error_msg = lw_sources_1lay%alloc(ncol, 1, k_dist)
       if(error_msg /= "") return
-      #
-      # Gas optics and sources
-      #
+      !
+      ! Gas optics and sources
+      !
       error_msg = k_dist%gas_optics(play_1lay, plev_1lay,               &
                                     tlay_1lay, tlay_1lay(1:ncol,1),     &
                                     gas_concs_1lay, optical_props_1lay, &
                                     lw_sources_1lay, tlev = tlev_1lay)
-      #                                                                  #
-      # Compute fluxes
-      #
+      !                                                                  !
+      ! Compute fluxes
+      !
       error_msg = rte_lw(optical_props_1lay, &
                          top_at_1,           &
                          lw_sources_1lay,    &
                          lower_bc, fluxes_1lev)
     else
-      #
-      # Shortwave specific variables
-      #
+      !
+      ! Shortwave specific variables
+      !
       if(.not. present(mu0)) then
         error_msg = "compute_bc: have to supply mu0 for solar calculations"
         return
@@ -183,9 +183,9 @@ contains
           error_msg =  optical_props_1lay%alloc_2str(ncol, 1, k_dist)
           if(error_msg /= "") return
       end select
-      #
-      # Gas optics and sources
-      #
+      !
+      ! Gas optics and sources
+      !
       error_msg = k_dist%gas_optics(play_1lay, plev_1lay,       &
                                     tlay_1lay,  gas_concs_1lay, &
                                     optical_props_1lay,         &
@@ -196,19 +196,19 @@ contains
                          lower_bc, lower_bc, fluxes_1lev)
     endif
   end function
-  # --------------------------------------------------------------------------------------
+  ! --------------------------------------------------------------------------------------
   function reduce_1lev(this, gpt_flux_up, gpt_flux_dn, spectral_disc, top_at_1, gpt_flux_dn_dir) result(error_msg)
     class(ty_fluxes_1lev),             intent(inout) :: this
-    real(kind=FT), dimension(:,:,:),   intent(in   ) :: gpt_flux_up # Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
-    real(kind=FT), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn # Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
-    class(ty_optical_props),           intent(in   ) :: spectral_disc  #< derived type with spectral information
+    real(kind=FT), dimension(:,:,:),   intent(in   ) :: gpt_flux_up ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
+    real(kind=FT), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
+    class(ty_optical_props),           intent(in   ) :: spectral_disc  !< derived type with spectral information
     logical,                           intent(in   ) :: top_at_1
     real(kind=FT), dimension(:,:,:), optional, &
-                                       intent(in   ) :: gpt_flux_dn_dir# Direct flux down
+                                       intent(in   ) :: gpt_flux_dn_dir! Direct flux down
     character(len=128)                               :: error_msg
-    # ------
+    ! ------
     integer :: ncol, nlev, ngpt, bottom_lev
-    # ------
+    ! ------
     error_msg = ""
     ncol = size(gpt_flux_up, DIM=1)
     nlev = size(gpt_flux_up, DIM=2)
@@ -218,9 +218,9 @@ contains
       return
     end if
     bottom_lev = merge(2, 1, top_at_1)
-   #
-   # Return the g-point flux at the bottomw of a two-layer domain
-   #
+   !
+   ! Return the g-point flux at the bottomw of a two-layer domain
+   !
     if(associated(this%gpt_flux_dn)) then
       if(any([size(this%gpt_flux_dn, 1) /= ncol,  &
               size(this%gpt_flux_dn, 2) /= ngpt])) then
@@ -234,10 +234,10 @@ contains
       end if
     end if
   end function reduce_1lev
-  # --------------------------------------------------------------------------------------
-  # Are any fluxes desired from this set of g-point fluxes? We can tell because memory will
-  #   be allocated for output
-  #
+  ! --------------------------------------------------------------------------------------
+  ! Are any fluxes desired from this set of g-point fluxes? We can tell because memory will
+  !   be allocated for output
+  !
   function are_desired_1lev(this)
     class(ty_fluxes_1lev), intent(in   ) :: this
     logical                              :: are_desired_1lev

--- a/RemainingFortranCode/mo_fluxes_bygpoint.f90
+++ b/RemainingFortranCode/mo_fluxes_bygpoint.f90
@@ -1,51 +1,51 @@
-# This code is part of
-# RRTM for GCM Applications - Parallel (RRTMGP)
-#
-# Eli Mlawer and Robert Pincus
-# Andre Wehe and Jennifer Delamere
-# email:  rrtmgp@aer.com
-#
-# Copyright 2018,  Atmospheric and Environmental Research and
-# Regents of the University of Colorado.  All right reserved.
-#
-# Use and duplication is permitted under the terms of the
-#    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
-#
-# This module is for packaging output quantities from RRTMGP based on spectral flux profiles
-#    This implementation reports the g-point fluxes
-#
+! This code is part of
+! RRTM for GCM Applications - Parallel (RRTMGP)
+!
+! Eli Mlawer and Robert Pincus
+! Andre Wehe and Jennifer Delamere
+! email:  rrtmgp@aer.com
+!
+! Copyright 2018,  Atmospheric and Environmental Research and
+! Regents of the University of Colorado.  All right reserved.
+!
+! Use and duplication is permitted under the terms of the
+!    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+!
+! This module is for packaging output quantities from RRTMGP based on spectral flux profiles
+!    This implementation reports the g-point fluxes
+!
 module mo_fluxes_bygpoint
   use mo_rte_kind,      only: FT
   use mo_fluxes,        only: ty_fluxes
   use mo_optical_props, only: ty_optical_props
   implicit none
 
-  # Output from radiation calculations
-  #   Data components are pointers so results can be written directly into memory
-  #   reduce() function accepts spectral flux profiles
+  ! Output from radiation calculations
+  !   Data components are pointers so results can be written directly into memory
+  !   reduce() function accepts spectral flux profiles
   type, extends(ty_fluxes) :: ty_fluxes_bygpoint
-    real(FT), dimension(:,:,:), pointer :: gpt_flux_up => NULL(), & # Band-by-band fluxes
-                                           gpt_flux_dn => NULL()    # (ncol, nlev, nband)
-    real(FT), dimension(:,:,:), pointer :: gpt_flux_net => NULL()   # Net (down - up)
-    real(FT), dimension(:,:,:), pointer :: gpt_flux_dn_dir => NULL() # Direct flux down
+    real(FT), dimension(:,:,:), pointer :: gpt_flux_up => NULL(), & ! Band-by-band fluxes
+                                           gpt_flux_dn => NULL()    ! (ncol, nlev, nband)
+    real(FT), dimension(:,:,:), pointer :: gpt_flux_net => NULL()   ! Net (down - up)
+    real(FT), dimension(:,:,:), pointer :: gpt_flux_dn_dir => NULL() ! Direct flux down
   contains
     procedure :: reduce => reduce_bygpoint
     procedure :: are_desired => are_desired_bygpoint
   end type ty_fluxes_bygpoint
 contains
-  # --------------------------------------------------------------------------------------
+  ! --------------------------------------------------------------------------------------
   function reduce_bygpoint(this, gpt_flux_up, gpt_flux_dn, spectral_disc, top_at_1, gpt_flux_dn_dir) result(error_msg)
     class(ty_fluxes_bygpoint),           intent(inout) :: this
-    real(kind=FT), dimension(:,:,:),   intent(in   ) :: gpt_flux_up # Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
-    real(kind=FT), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn # Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
-    class(ty_optical_props),           intent(in   ) :: spectral_disc  #< derived type with spectral information
+    real(kind=FT), dimension(:,:,:),   intent(in   ) :: gpt_flux_up ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
+    real(kind=FT), dimension(:,:,:),   intent(in   ) :: gpt_flux_dn ! Fluxes by gpoint [W/m2](ncol, nlay+1, ngpt)
+    class(ty_optical_props),           intent(in   ) :: spectral_disc  !< derived type with spectral information
     logical,                           intent(in   ) :: top_at_1
     real(kind=FT), dimension(:,:,:), optional, &
-                                       intent(in   ) :: gpt_flux_dn_dir# Direct flux down
+                                       intent(in   ) :: gpt_flux_dn_dir! Direct flux down
     character(len=128)                               :: error_msg
-    # ------
+    ! ------
     integer :: ncol, nlev, ngpt, nbnd
-    # ------
+    ! ------
     error_msg = ""
     ncol = size(gpt_flux_up, DIM=1)
     nlev = size(gpt_flux_up, DIM=2)
@@ -89,10 +89,10 @@ contains
     end if
   end function reduce_bygpoint
 
-    # --------------------------------------------------------------------------------------
-    # Are any fluxes desired from this set of g-point fluxes? We can tell because memory will
-    #   be allocated for output
-    #
+    ! --------------------------------------------------------------------------------------
+    ! Are any fluxes desired from this set of g-point fluxes? We can tell because memory will
+    !   be allocated for output
+    !
     function are_desired_bygpoint(this)
       class(ty_fluxes_bygpoint), intent(in   ) :: this
       logical                                  :: are_desired_bygpoint

--- a/RemainingFortranCode/mo_heating_rates.f90
+++ b/RemainingFortranCode/mo_heating_rates.f90
@@ -1,34 +1,34 @@
-#
-# Eli Mlawer and Robert Pincus
-# Andre Wehe and Jennifer Delamere
-# email:  rrtmgp@aer.com
-#
-# Copyright 2016-2017,  Atmospheric and Environmental Research and
-# Regents of the University of Colorado.  All right reserved.
-#
-# Use and duplication is permitted under the terms of the
-#    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
-#
-# Description:  Heating rate calculation
+!
+! Eli Mlawer and Robert Pincus
+! Andre Wehe and Jennifer Delamere
+! email:  rrtmgp@aer.com
+!
+! Copyright 2016-2017,  Atmospheric and Environmental Research and
+! Regents of the University of Colorado.  All right reserved.
+!
+! Use and duplication is permitted under the terms of the
+!    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+!
+! Description:  Heating rate calculation
 
 module mo_heating_rates
   use mo_rte_kind,      only: FT, wl
-  use mo_rrtmgp_constants, only: cp_dry, grav # Only needed for heating rate calculation
+  use mo_rrtmgp_constants, only: cp_dry, grav ! Only needed for heating rate calculation
   implicit none
   private
   public ::  compute_heating_rate
 contains
-  # Compute heating rate from fluxes
-  # heating rate H [K/sec] = 1/(rho cp) d f_net/d z
-  # Here use hydrostatic equation for density and heat capacity of dry air
+  ! Compute heating rate from fluxes
+  ! heating rate H [K/sec] = 1/(rho cp) d f_net/d z
+  ! Here use hydrostatic equation for density and heat capacity of dry air
   function compute_heating_rate(flux_up, flux_dn, plev, heating_rate) result(error_msg)
-    real(FT), dimension(:,:), intent(in ) :: flux_up, flux_dn, & #< fluxes at interfaces [W/m2]
-                                             plev                #< pressure at interfaces [Pa]
-    real(FT), dimension(:,:), intent(out) :: heating_rate        #< heating rate within layer [K/sec]
+    real(FT), dimension(:,:), intent(in ) :: flux_up, flux_dn, & !< fluxes at interfaces [W/m2]
+                                             plev                !< pressure at interfaces [Pa]
+    real(FT), dimension(:,:), intent(out) :: heating_rate        !< heating rate within layer [K/sec]
     character(len=128)                    :: error_msg
-    # ---------
+    ! ---------
     integer :: ncol, nlay, ilay
-    # ---------
+    ! ---------
     error_msg = ""
     ncol = size(flux_up, 1)
     nlay = size(flux_up, 2) - 1

--- a/RemainingFortranCode/mo_rrtmgp_clr_all_sky.f90
+++ b/RemainingFortranCode/mo_rrtmgp_clr_all_sky.f90
@@ -1,24 +1,24 @@
-# This code is part of
-# RRTM for GCM Applications - Parallel (RRTMGP)
-#
-# Eli Mlawer and Robert Pincus
-# Andre Wehe and Jennifer Delamere
-# email:  rrtmgp@aer.com
-#
-# Copyright 2017,  Atmospheric and Environmental Research and
-# Regents of the University of Colorado.  All right reserved.
-#
-# Use and duplication is permitted under the terms of the
-#    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
-#
+! This code is part of
+! RRTM for GCM Applications - Parallel (RRTMGP)
+!
+! Eli Mlawer and Robert Pincus
+! Andre Wehe and Jennifer Delamere
+! email:  rrtmgp@aer.com
+!
+! Copyright 2017,  Atmospheric and Environmental Research and
+! Regents of the University of Colorado.  All right reserved.
+!
+! Use and duplication is permitted under the terms of the
+!    BSD 3-clause license, see http://opensource.org/licenses/BSD-3-Clause
+!
 
-#
-# This module provides an interface to RRTMGP for a common use case --
-#   users want to start from gas concentrations, pressures, and temperatures,
-#   and compute clear-sky (aerosol plus gases) and all-sky fluxes.
-# The routines here have the same names as those in mo_rrtmgp_[ls]w; normally users
-#   will use either this module or the underling modules, but not both
-#
+!
+! This module provides an interface to RRTMGP for a common use case --
+!   users want to start from gas concentrations, pressures, and temperatures,
+!   and compute clear-sky (aerosol plus gases) and all-sky fluxes.
+! The routines here have the same names as those in mo_rrtmgp_[ls]w; normally users
+!   will use either this module or the underling modules, but not both
+!
 module mo_rrtmgp_clr_all_sky
   use mo_rte_kind,   only: FT
   use mo_gas_optics, &
@@ -37,47 +37,47 @@ module mo_rrtmgp_clr_all_sky
 
   public :: rte_lw, rte_sw
 contains
-  # --------------------------------------------------
-  #
-  # Interfaces using clear (gas + aerosol) and all-sky categories, starting from
-  #   pressures, temperatures, and gas amounts for the gas contribution
-  #
-  # --------------------------------------------------
+  ! --------------------------------------------------
+  !
+  ! Interfaces using clear (gas + aerosol) and all-sky categories, starting from
+  !   pressures, temperatures, and gas amounts for the gas contribution
+  !
+  ! --------------------------------------------------
   function rte_lw(k_dist, gas_concs, p_lay, t_lay, p_lev,    &
                      t_sfc, sfc_emis, cloud_props,           &
                      allsky_fluxes, clrsky_fluxes,           &
                      aer_props, col_dry, t_lev, inc_flux, n_gauss_angles) result(error_msg)
-    class(ty_gas_optics),              intent(in   ) :: k_dist       #< derived type with spectral information
-    type(ty_gas_concs),                intent(in   ) :: gas_concs    #< derived type encapsulating gas concentrations
-    real(FT), dimension(:,:),          intent(in   ) :: p_lay, t_lay #< pressure [Pa], temperature [K] at layer centers (ncol,nlay)
-    real(FT), dimension(:,:),          intent(in   ) :: p_lev        #< pressure at levels/interfaces [Pa] (ncol,nlay+1)
-    real(FT), dimension(:),            intent(in   ) :: t_sfc     #< surface temperature           [K]  (ncol)
-    real(FT), dimension(:,:),          intent(in   ) :: sfc_emis  #< emissivity at surface         []   (nband, ncol)
-    class(ty_optical_props_arry),      intent(in   ) :: cloud_props #< cloud optical properties (ncol,nlay,ngpt)
+    class(ty_gas_optics),              intent(in   ) :: k_dist       !< derived type with spectral information
+    type(ty_gas_concs),                intent(in   ) :: gas_concs    !< derived type encapsulating gas concentrations
+    real(FT), dimension(:,:),          intent(in   ) :: p_lay, t_lay !< pressure [Pa], temperature [K] at layer centers (ncol,nlay)
+    real(FT), dimension(:,:),          intent(in   ) :: p_lev        !< pressure at levels/interfaces [Pa] (ncol,nlay+1)
+    real(FT), dimension(:),            intent(in   ) :: t_sfc     !< surface temperature           [K]  (ncol)
+    real(FT), dimension(:,:),          intent(in   ) :: sfc_emis  !< emissivity at surface         []   (nband, ncol)
+    class(ty_optical_props_arry),      intent(in   ) :: cloud_props !< cloud optical properties (ncol,nlay,ngpt)
     class(ty_fluxes),                  intent(inout) :: allsky_fluxes, clrsky_fluxes
 
-    # Optional inputs
+    ! Optional inputs
     class(ty_optical_props_arry),  &
-              optional,       intent(in ) :: aer_props   #< aerosol optical properties
+              optional,       intent(in ) :: aer_props   !< aerosol optical properties
     real(FT), dimension(:,:), &
-              optional,       intent(in ) :: col_dry #< Molecular number density (ncol, nlay)
+              optional,       intent(in ) :: col_dry !< Molecular number density (ncol, nlay)
     real(FT), dimension(:,:), target, &
-              optional,       intent(in ) :: t_lev     #< temperature at levels [K] (ncol, nlay+1)
+              optional,       intent(in ) :: t_lev     !< temperature at levels [K] (ncol, nlay+1)
     real(FT), dimension(:,:), target, &
-              optional,       intent(in ) :: inc_flux   #< incident flux at domain top [W/m2] (ncol, ngpts)
-    integer,  optional,       intent(in ) :: n_gauss_angles # Number of angles used in Gaussian quadrature (no-scattering solution)
+              optional,       intent(in ) :: inc_flux   !< incident flux at domain top [W/m2] (ncol, ngpts)
+    integer,  optional,       intent(in ) :: n_gauss_angles ! Number of angles used in Gaussian quadrature (no-scattering solution)
     character(len=128)                    :: error_msg
-    # --------------------------------
-    # Local variables
-    #
+    ! --------------------------------
+    ! Local variables
+    !
     class(ty_optical_props_arry), allocatable :: optical_props
     type(ty_source_func_lw)                   :: sources
 
     integer :: ncol, nlay, ngpt, nband, nstr
     logical :: top_at_1
-    # --------------------------------
-    # Problem sizes
-    #
+    ! --------------------------------
+    ! Problem sizes
+    !
     error_msg = ""
 
     ncol  = size(p_lay, 1)
@@ -87,9 +87,9 @@ contains
 
     top_at_1 = p_lay(1, 1) < p_lay(1, nlay)
 
-    # ------------------------------------------------------------------------------------
-    #  Error checking
-    #
+    ! ------------------------------------------------------------------------------------
+    !  Error checking
+    !
     if(present(aer_props)) then
       if(any([aer_props%get_ncol(), &
               aer_props%get_nlay()] /= [ncol, nlay])) &
@@ -111,11 +111,11 @@ contains
     end if
     if(len_trim(error_msg) > 0) return
 
-    # ------------------------------------------------------------------------------------
-    # Optical properties arrays
-    #
+    ! ------------------------------------------------------------------------------------
+    ! Optical properties arrays
+    !
     select type(cloud_props)
-      class is (ty_optical_props_1scl) # No scattering
+      class is (ty_optical_props_1scl) ! No scattering
         allocate(ty_optical_props_1scl::optical_props)
       class is (ty_optical_props_2str)
         allocate(ty_optical_props_2str::optical_props)
@@ -127,7 +127,7 @@ contains
     error_msg = optical_props%init(k_dist)
     if(len_trim(error_msg) > 0) return
     select type (optical_props)
-      class is (ty_optical_props_1scl) # No scattering
+      class is (ty_optical_props_1scl) ! No scattering
         error_msg = optical_props%alloc_1scl(ncol, nlay)
       class is (ty_optical_props_2str)
         error_msg = optical_props%alloc_2str(ncol, nlay)
@@ -136,24 +136,24 @@ contains
     end select
     if (error_msg /= '') return
 
-    #
-    # Source function
-    #
+    !
+    ! Source function
+    !
     error_msg = sources%init(k_dist)
     error_msg = sources%alloc(ncol, nlay)
     if (error_msg /= '') return
-    # ------------------------------------------------------------------------------------
-    # Clear skies
-    #
-    # Gas optical depth -- pressure need to be expressed as Pa
-    #
+    ! ------------------------------------------------------------------------------------
+    ! Clear skies
+    !
+    ! Gas optical depth -- pressure need to be expressed as Pa
+    !
     error_msg = k_dist%gas_optics(p_lay, p_lev, t_lay, t_sfc, gas_concs, &
                                   optical_props, sources,                &
                                   col_dry, t_lev)
     if (error_msg /= '') return
-    # ----------------------------------------------------
-    # Clear sky is gases + aerosols (if they're supplied)
-    #
+    ! ----------------------------------------------------
+    ! Clear sky is gases + aerosols (if they're supplied)
+    !
     if(present(aer_props)) error_msg = aer_props%increment(optical_props)
     if(error_msg /= '') return
 
@@ -161,9 +161,9 @@ contains
                             sfc_emis, clrsky_fluxes,          &
                             inc_flux, n_gauss_angles)
     if(error_msg /= '') return
-    # ------------------------------------------------------------------------------------
-    # All-sky fluxes = clear skies + clouds
-    #
+    ! ------------------------------------------------------------------------------------
+    ! All-sky fluxes = clear skies + clouds
+    !
     error_msg = cloud_props%increment(optical_props)
     if(error_msg /= '') return
 
@@ -173,40 +173,40 @@ contains
 
     call sources%finalize()
   end function rte_lw
-  # --------------------------------------------------
+  ! --------------------------------------------------
   function rte_sw(k_dist, gas_concs, p_lay, t_lay, p_lev, &
                                  mu0, sfc_alb_dir, sfc_alb_dif, cloud_props, &
                                  allsky_fluxes, clrsky_fluxes,           &
                                  aer_props, col_dry, inc_flux, tsi_scaling) result(error_msg)
-    class(ty_gas_optics),              intent(in   ) :: k_dist       #< derived type with spectral information
-    type(ty_gas_concs),                intent(in   ) :: gas_concs    #< derived type encapsulating gas concentrations
-    real(FT), dimension(:,:),          intent(in   ) :: p_lay, t_lay #< pressure [Pa], temperature [K] at layer centers (ncol,nlay)
-    real(FT), dimension(:,:),          intent(in   ) :: p_lev        #< pressure at levels/interfaces [Pa] (ncol,nlay+1)
-    real(FT), dimension(:  ),          intent(in   ) :: mu0          #< cosine of solar zenith angle
+    class(ty_gas_optics),              intent(in   ) :: k_dist       !< derived type with spectral information
+    type(ty_gas_concs),                intent(in   ) :: gas_concs    !< derived type encapsulating gas concentrations
+    real(FT), dimension(:,:),          intent(in   ) :: p_lay, t_lay !< pressure [Pa], temperature [K] at layer centers (ncol,nlay)
+    real(FT), dimension(:,:),          intent(in   ) :: p_lev        !< pressure at levels/interfaces [Pa] (ncol,nlay+1)
+    real(FT), dimension(:  ),          intent(in   ) :: mu0          !< cosine of solar zenith angle
     real(FT), dimension(:,:),          intent(in   ) :: sfc_alb_dir, sfc_alb_dif
-                                                        #  surface albedo for direct and diffuse radiation (band, col)
-    class(ty_optical_props_arry),      intent(in   ) :: cloud_props #< cloud optical properties (ncol,nlay,ngpt)
+                                                        !  surface albedo for direct and diffuse radiation (band, col)
+    class(ty_optical_props_arry),      intent(in   ) :: cloud_props !< cloud optical properties (ncol,nlay,ngpt)
     class(ty_fluxes),                  intent(inout) :: allsky_fluxes, clrsky_fluxes
 
-    # Optional inputs
+    ! Optional inputs
     class(ty_optical_props_arry),   target, &
-              optional,       intent(in ) :: aer_props   #< aerosol optical properties
+              optional,       intent(in ) :: aer_props   !< aerosol optical properties
     real(FT), dimension(:,:), &
-              optional,       intent(in ) :: col_dry, &  #< Molecular number density (ncol, nlay)
-                                             inc_flux    #< incident flux at domain top [W/m2] (ncol, ngpts)
-    real(FT), optional,       intent(in ) :: tsi_scaling #< Optional scaling for total solar irradiance
+              optional,       intent(in ) :: col_dry, &  !< Molecular number density (ncol, nlay)
+                                             inc_flux    !< incident flux at domain top [W/m2] (ncol, ngpts)
+    real(FT), optional,       intent(in ) :: tsi_scaling !< Optional scaling for total solar irradiance
 
     character(len=128)                    :: error_msg
-    # --------------------------------
-    # Local variables
-    #
+    ! --------------------------------
+    ! Local variables
+    !
     class(ty_optical_props_arry), allocatable :: optical_props
     real(FT), dimension(:,:),     allocatable :: toa_flux
     integer :: ncol, nlay, ngpt, nband, nstr
     logical :: top_at_1
-    # --------------------------------
-    # Problem sizes
-    #
+    ! --------------------------------
+    ! Problem sizes
+    !
     error_msg = ""
 
     ncol  = size(p_lay, 1)
@@ -216,9 +216,9 @@ contains
 
     top_at_1 = p_lay(1, 1) < p_lay(1, nlay)
 
-    # ------------------------------------------------------------------------------------
-    #  Error checking
-    #
+    ! ------------------------------------------------------------------------------------
+    !  Error checking
+    !
     if(present(inc_flux) .and. present(tsi_scaling)) &
       error_msg = "rrtmpg_sw: only one of inc_flux, tsi_scaling may be supplied."
 
@@ -242,12 +242,12 @@ contains
     end if
     if(len_trim(error_msg) > 0) return
 
-    # ------------------------------------------------------------------------------------
-    #
-    # Optical properties arrays
-    #
+    ! ------------------------------------------------------------------------------------
+    !
+    ! Optical properties arrays
+    !
     select type(cloud_props)
-      class is (ty_optical_props_1scl) # No scattering
+      class is (ty_optical_props_1scl) ! No scattering
         allocate(ty_optical_props_1scl::optical_props)
       class is (ty_optical_props_2str)
         allocate(ty_optical_props_2str::optical_props)
@@ -260,7 +260,7 @@ contains
                                    k_dist%get_band_lims_gpoint())
     if(len_trim(error_msg) > 0) return
     select type (optical_props)
-      class is (ty_optical_props_1scl) # No scattering
+      class is (ty_optical_props_1scl) ! No scattering
         error_msg = optical_props%alloc_1scl(ncol, nlay)
       class is (ty_optical_props_2str)
         error_msg = optical_props%alloc_2str(ncol, nlay)
@@ -270,23 +270,23 @@ contains
     if (error_msg /= '') return
 
     allocate(toa_flux(ncol, ngpt))
-    # ------------------------------------------------------------------------------------
-    # Clear skies
-    #
-    # Gas optical depth -- pressure need to be expressed as Pa
-    #
+    ! ------------------------------------------------------------------------------------
+    ! Clear skies
+    !
+    ! Gas optical depth -- pressure need to be expressed as Pa
+    !
     error_msg = k_dist%gas_optics(p_lay, p_lev, t_lay, gas_concs,  &
                                   optical_props, toa_flux,                          &
                                   col_dry)
     if (error_msg /= '') return
-    #
-    # If users have supplied an incident flux, use that
-    #
+    !
+    ! If users have supplied an incident flux, use that
+    !
     if(present(inc_flux))    toa_flux(:,:) = inc_flux(:,:)
     if(present(tsi_scaling)) toa_flux(:,:) = toa_flux(:,:) * tsi_scaling
-    # ----------------------------------------------------
-    # Clear sky is gases + aerosols (if they're supplied)
-    #
+    ! ----------------------------------------------------
+    ! Clear sky is gases + aerosols (if they're supplied)
+    !
     if(present(aer_props)) error_msg = aer_props%increment(optical_props)
     if(error_msg /= '') return
 
@@ -296,9 +296,9 @@ contains
                                clrsky_fluxes)
 
     if(error_msg /= '') return
-    # ------------------------------------------------------------------------------------
-    # All-sky fluxes = clear skies + clouds
-    #
+    ! ------------------------------------------------------------------------------------
+    ! All-sky fluxes = clear skies + clouds
+    !
     error_msg = cloud_props%increment(optical_props)
     if(error_msg /= '') return
 


### PR DESCRIPTION
Moves all code not yet translated to a separate folder. Also, converts comments back to f90 comments for readability.